### PR TITLE
Pass empty string to chart if no data is set

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -88,7 +88,7 @@ function chartLoaded() {
         .metricPrefix(__dw.params.metricPrefix)
         .theme(dw.theme(__dw.params.themeId));
     return chart.load(
-        __dw.params.data,
+        __dw.params.data || '',
         __dw.params.preview ? undefined : __dw.params.chartJSON.externalData
     );
 }


### PR DESCRIPTION
This PR changes current behaviour to pass an empty string to chart instead of `undefined` when no data has been set.

This ensures that choropleth and symbol maps can be displayed in step 2 before data has been set.

To test you will need to use the [node-publishing branch of simple-maps](https://github.com/datawrapper/plugin-simple-maps/tree/node-publishing).