### PR TITLE
inject custom chart css

### DIFF
--- a/lib/Chart.svelte
+++ b/lib/Chart.svelte
@@ -216,6 +216,15 @@ Please make sure you called __(key) with a key of type "string".
             };
         }
 
+        // inject custom-css
+        let customCSS;
+        if ((customCSS = get(chart, 'metadata.publish.custom-css'))) {
+            const style = document.createElement('style');
+            document.head.appendChild(style);
+            style.type = 'text/css';
+            style.appendChild(document.createTextNode(customCSS));
+        }
+
         render(data);
 
         // load & execute plugins


### PR DESCRIPTION
there isn't an easier way to inject CSS into a svelte component (I checked with the svelte chat). of course, in sapper we could expose the css as "file" using `<svelte:head><link rel="stylesheet"></svelte:head>` but then we'd have to find another solution for published charts. this way the CSS is injected dynamically which should work both ways.