### PR TITLE
fix: use correct metadata field (fix copy and paste)

### DIFF
--- a/lib/Chart.svelte
+++ b/lib/Chart.svelte
@@ -36,7 +36,7 @@
             id: 'description',
             region: 'header',
             priority: 20,
-            test: ({ chart }) => get(chart, 'metadata.annotate.notes'),
+            test: ({ chart }) => get(chart, 'metadata.describe.intro'),
             component: Description
         },
         {


### PR DESCRIPTION
just a copy and paste error I found while fixing something in locator maps