### PR TITLE
inject custom css into chart preview

### DIFF
--- a/lib/Chart.svelte
+++ b/lib/Chart.svelte
@@ -22,7 +22,7 @@
     $: publishData = data.publishData;
     $: locale = data.visJSON.locale;
 
-    $: customCSS = get(chart, 'metadata.publish.custom-css', '');
+    $: customCSS = purifyHtml(get(chart, 'metadata.publish.custom-css', ''), '');
 
     const clean = s => purifyHtml(s, '<a><span><b>');
 


### PR DESCRIPTION
this injects the custom css for chart **previews**. for published charts see https://github.com/datawrapper/api/pull/144

the reason this only affects previews is that the `<svelte:header>` is ignore in server-side rendering