### PR TITLE
feat: enable links in based on byline

### DIFF
--- a/lib/blocks/Byline.svelte
+++ b/lib/blocks/Byline.svelte
@@ -1,7 +1,7 @@
 <script>
     // external props
     export let props;
-    const { get, __ } = props;
+    const { get, purifyHtml, __ } = props;
     $: chart = props.chart;
     $: theme = props.theme;
     $: caption = props.caption;
@@ -33,6 +33,7 @@
 
 {#if chart.basedOnByline}
     {#if needBrackets}({/if}
-    {__(forkCaption)} {chart.basedOnByline}
+    {__(forkCaption)}
+    {@html purifyHtml(chart.basedOnByline)}
     {#if needBrackets}){/if}
 {/if}


### PR DESCRIPTION
The byline coming from the River can include `<a>` tags. Therefore we need to enable HTML here. 