### PR TITLE
add region belowFooter

### DIFF
--- a/lib/BlocksRegion.svelte
+++ b/lib/BlocksRegion.svelte
@@ -5,22 +5,24 @@
     export let blocks;
 </script>
 
-<div class={name}>
-    {#each blocks as block}
-        <div class="block block-{block.id}" class:export-text={block.exportText}>
-            {#if block.prepend}
-                <span class="prepend">
-                    {@html clean(block.prepend)}
+{#if blocks.length}
+    <div class={name}>
+        {#each blocks as block}
+            <div class="block block-{block.id}" class:export-text={block.exportText}>
+                {#if block.prepend}
+                    <span class="prepend">
+                        {@html clean(block.prepend)}
+                    </span>
+                {/if}
+                <span class="block-inner">
+                    <svelte:component this={block.component} props={block.props} />
                 </span>
-            {/if}
-            <span class="block-inner">
-                <svelte:component this={block.component} props={block.props} />
-            </span>
-            {#if block.append}
-                <span class="append">
-                    {@html clean(block.append)}
-                </span>
-            {/if}
-        </div>
-    {/each}
-</div>
+                {#if block.append}
+                    <span class="append">
+                        {@html clean(block.append)}
+                    </span>
+                {/if}
+            </div>
+        {/each}
+    </div>
+{/if}

--- a/lib/BlocksRegion.svelte
+++ b/lib/BlocksRegion.svelte
@@ -1,0 +1,26 @@
+<script>
+    import { clean } from './shared';
+
+    export let name;
+    export let blocks;
+</script>
+
+<div class={name}>
+    {#each blocks as block}
+        <div class="block block-{block.id}" class:export-text={block.exportText}>
+            {#if block.prepend}
+                <span class="prepend">
+                    {@html clean(block.prepend)}
+                </span>
+            {/if}
+            <span class="block-inner">
+                <svelte:component this={block.component} props={block.props} />
+            </span>
+            {#if block.append}
+                <span class="append">
+                    {@html clean(block.append)}
+                </span>
+            {/if}
+        </div>
+    {/each}
+</div>

--- a/lib/BlocksRegion.svelte
+++ b/lib/BlocksRegion.svelte
@@ -8,7 +8,7 @@
 {#if blocks.length}
     <div class={name}>
         {#each blocks as block}
-            <div class="block block-{block.id}" class:export-text={block.exportText}>
+            <div class="block {block.id}-block" class:export-text={block.exportText}>
                 {#if block.prepend}
                     <span class="prepend">
                         {@html clean(block.prepend)}

--- a/lib/Chart.svelte
+++ b/lib/Chart.svelte
@@ -323,7 +323,7 @@ Please make sure you called __(key) with a key of type "string".
                     {#if i}
                         <span class="separator separator-before-{block.id}" />
                     {/if}
-                    <span class="footer-block {block.id}-block block-{block.id}">
+                    <span class="footer-block {block.id}-block">
                         {#if block.prepend}
                             <span class="prepend">
                                 {@html clean(block.prepend)}

--- a/lib/blocks/Watermark.svelte
+++ b/lib/blocks/Watermark.svelte
@@ -1,9 +1,18 @@
 <script>
-    import purifyHtml from '@datawrapper/shared/purifyHtml';
     import estimateTextWidth from '@datawrapper/shared/estimateTextWidth';
 
-    export let text;
-    export let monospace;
+    export let props;
+    const { get, purifyHtml } = props;
+    $: theme = props.theme;
+    $: chart = props.chart;
+
+    $: monospace = get(theme, 'data.options.watermark.monospace', false);
+    $: field = get(theme, 'data.options.watermark.custom-field');
+    $: text = get(theme, 'data.options.watermark')
+        ? field
+            ? get(chart, `metadata.custom.${field}`, '')
+            : get(theme, 'data.options.watermark.text', 'CONFIDENTIAL')
+        : false;
 
     let width;
     let height;

--- a/lib/dw/utils/getNonChartHeight.js
+++ b/lib/dw/utils/getNonChartHeight.js
@@ -28,7 +28,7 @@ export function getNonChartHeight() {
             !hasClass(el, 'noscript') &&
             !hasClass(el, 'hidden') &&
             !hasClass(el, 'filter-ui') &&
-            !hasClass(el, 'dw-below-footer') &&
+            !hasClass(el, 'dw-after-body') &&
             !hasClass(el, 'dw-chart-body')
         ) {
             h += Number(outerHeight(el, true));
@@ -42,7 +42,7 @@ export function getNonChartHeight() {
         return getComputedStyle(document.querySelector(selector))[property].replace('px', '');
     }
 
-    const selectors = ['.dw-chart', '.dw-chart #chart'];
+    const selectors = ['.dw-chart', '.dw-chart-body'];
     const properties = [
         'padding-top',
         'padding-bottom',

--- a/lib/render.js
+++ b/lib/render.js
@@ -11,6 +11,7 @@ import {
     addClass,
     removeClass,
     domReady,
+    getNonChartHeight,
     getMaxChartHeight
 } from './dw/utils';
 import get from '@datawrapper/shared/get';
@@ -25,14 +26,12 @@ function renderChart() {
         // reset and remove it
         __dw.vis.reset();
     }
-    const $chart = document.querySelector('#chart');
+    const $chart = document.querySelector('.dw-chart-body');
 
     const belowChartHeight =
-        Math.max(
-            getHeight('.footer-left'),
-            getHeight('.footer-center'),
-            getHeight('.footer-right')
-        ) + getHeight('.dw-chart-above-footer');
+        getHeight('.dw-chart-footer') +
+        getHeight('.dw-chart-above-footer') +
+        getHeight('.dw-chart-below-footer');
 
     if (belowChartHeight > 0) {
         addClass(document.querySelector('.dw-chart-body'), 'content-below-chart');
@@ -237,8 +236,7 @@ export default function render({
                 }
 
                 desiredHeight =
-                    dw.utils.getNonChartHeight() +
-                    __dw.vis.chart().get('metadata.publish.chart-height');
+                    getNonChartHeight() + __dw.vis.chart().get('metadata.publish.chart-height');
             }
 
             // datawrapper responsive embed

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -1,0 +1,5 @@
+import purifyHtml from '@datawrapper/shared/purifyHtml';
+
+export function clean(s) {
+    return purifyHtml(s, '<a><span><b><br><br/><i><strong><sup><sub><strike><u><em><tt>');
+}

--- a/lib/styles.less
+++ b/lib/styles.less
@@ -665,6 +665,6 @@ html[xmlns] .clearfix {
     }
 }
 
-.dw-below-footer {
+.dw-after-body {
     position: absolute;
 }


### PR DESCRIPTION
Changes:
* this PR turns `belowFooter` into a "proper" region that can be used to display blocks such as Notes below the actual footer
* this also adds a new Svelte component `BlocksRegion` so we're not repeating the markup for the `header`, `aboveFooter` and `belowFooter` regions.
* a new region `afterBody` has been added (although I think we used to have this at some point), which can be used for blocks that should not be measured when the available chart height is determined (e.g. SocialSharing)
* the `Watermark` component was refactored to behave more like the other core blocks. Meaning that it's defined in the `coreBlocks` array and it is using the same `props` and `test` mechanism as the other blocks.
* there have also been minor adjustments to the chart height computation following the change of the `belowFooter` region 