### PR TITLE
Small changes / fixes

### DIFF
--- a/lib/blocks/Logo.svelte
+++ b/lib/blocks/Logo.svelte
@@ -12,8 +12,8 @@
 
 {#if logo.link}
     <a href={logo.link} target="_blank" rel="noopener noreferrer">
-        <LogoInner {logo} {purifyHtml} />
+        <LogoInner {logo} {purifyHtml} {theme} />
     </a>
 {:else}
-    <LogoInner {logo} {purifyHtml} />
+    <LogoInner {logo} {purifyHtml} {theme} />
 {/if}

--- a/lib/blocks/LogoInner.svelte
+++ b/lib/blocks/LogoInner.svelte
@@ -1,6 +1,7 @@
 <script>
     export let purifyHtml;
     export let logo;
+    export let theme;
 </script>
 
 {#if logo.url}

--- a/lib/styles.less
+++ b/lib/styles.less
@@ -315,7 +315,6 @@ body {
         font-weight: @typography_notes_fontWeight;
         text-transform: @typography_notes_textTransform;
         font-size: @typography_notes_fontSize;
-        font-size: @typography_aboveFooter_fontSize;
             & when not (@typography_notes_lineHeight = __UNDEFINED__) {
                 line-height: @typography_notes_lineHeight * 1px;
             }

--- a/lib/styles.less
+++ b/lib/styles.less
@@ -295,7 +295,9 @@ body {
         font-weight: @typography_aboveFooter_fontWeight;
         text-transform: @typography_aboveFooter_textTransform;
         font-size: @typography_aboveFooter_fontSize;
-        line-height: @typography_aboveFooter_lineHeight;
+            & when not (@typography_aboveFooter_lineHeight = __UNDEFINED__) {
+                line-height: @typography_aboveFooter_lineHeight * 1px;
+            }
         font-style: if(@typography_aboveFooter_cursive = 1, italic, normal);
         text-decoration: if(@typography_aboveFooter_underlined = 1, underline, none);
         color: @typography_aboveFooter_color;
@@ -313,7 +315,10 @@ body {
         font-weight: @typography_notes_fontWeight;
         text-transform: @typography_notes_textTransform;
         font-size: @typography_notes_fontSize;
-        line-height: @typography_notes_lineHeight;
+        font-size: @typography_aboveFooter_fontSize;
+            & when not (@typography_notes_lineHeight = __UNDEFINED__) {
+                line-height: @typography_notes_lineHeight * 1px;
+            }
         font-style: if(@typography_notes_cursive = 1, italic, normal);
         text-decoration: if(@typography_notes_underlined = 1, underline, none);
         color: @typography_notes_color;
@@ -329,7 +334,9 @@ body {
         font-weight: @typography_belowFooter_fontWeight;
         text-transform: @typography_belowFooter_textTransform;
         font-size: @typography_belowFooter_fontSize;
-        line-height: @typography_belowFooter_lineHeight;
+            & when not (@typography_belowFooter_lineHeight = __UNDEFINED__) {
+                line-height: @typography_belowFooter_lineHeight * 1px;
+            }
         font-style: if(@typography_belowFooter_cursive = 1, italic, normal);
         text-decoration: if(@typography_belowFooter_underlined = 1, underline, none);
         color: @typography_belowFooter_color;
@@ -388,7 +395,9 @@ body {
         font-weight: @typography_footer_fontWeight;
         font-size: @typography_footer_fontSize;
         text-transform: @typography_footer_textTransform;
-        line-height: @typography_footer_lineHeight;
+            & when not (@typography_footer_lineHeight = __UNDEFINED__) {
+                line-height: @typography_footer_lineHeight * 1px;
+            }
         font-style: if(@typography_footer_cursive = 1, italic, normal);
         text-decoration: if(@typography_footer_underlined = 1, underline, none);
         color: @typography_footer_color;
@@ -404,7 +413,9 @@ body {
         border-bottom: @style_footer_links_border_bottom;
         font-family: @typography_links_typeface;
         font-weight: @typography_links_fontWeight;
-        line-height: @typography_links_lineHeight;
+            & when not (@typography_links_lineHeight = __UNDEFINED__) {
+                line-height: @typography_links_lineHeight * 1px;
+            }
         font-style: if(@typography_links_cursive = 1, italic, normal);
         text-decoration: if(@typography_links_underlined = 1, underline, nonee);
         color: @typography_links_color;

--- a/lib/styles.less
+++ b/lib/styles.less
@@ -101,7 +101,7 @@ body {
         }
 
         .description-block {
-            margin: 5px 0 10px !important;
+            margin: 5px 0 10px;
             margin: @style_header_description_margin;
             padding: @style_header_description_padding;
             text-align: @style_header_description_textAlign;


### PR DESCRIPTION
Small changes/fixes:

**styles.less**
- line-height 
previously line-heights were sometimes defined with px, and sometimes without. This was a mistake on production for which there has been a pending fix for a while, that got carried over. Would be better if all line-heights were 'px'
- margin on `description-block`
don't set default as `!important` otherwise theme-defined margin isn't respected. Not sure why `!important` was added and if there was a good reason, ideally no important should have to be used here.

**Logo.svelte**
themes with logos were breaking because Logo.inner wasn't passed the `theme` object that is used to define the `alt` attribute