### PR TITLE
feat: re-render visualization when props change

### DIFF
--- a/lib/Chart.svelte
+++ b/lib/Chart.svelte
@@ -17,6 +17,7 @@
     import { clean } from './shared';
     import { loadScript, loadStylesheet } from '@datawrapper/shared/fetch';
     import render from './render.js';
+    import { getMaxChartHeight } from './dw/utils';
 
     export let data = {};
     export let theme = {};
@@ -160,6 +161,18 @@
         });
     }
 
+    async function checkHeightAndRender() {
+        if (globalThis.__dw) {
+            const currentHeight = __dw.vis.size()[1];
+            await tick();
+            /* check after tick to get the new values after browser had time for layout and paint */
+            const newHeight = getMaxChartHeight(document.querySelector('.dw-chart-body'));
+            if (currentHeight !== newHeight) {
+                __dw.render();
+            }
+        }
+    }
+
     let regions;
     $: {
         // build all the region
@@ -178,9 +191,7 @@
             afterBody: getBlocks(allBlocks, 'afterBody', { chart, data, theme, isStyleStatic })
         };
 
-        if (globalThis.__dw) {
-            __dw.render();
-        }
+        checkHeightAndRender();
     }
 
     // plain style means no header and footer

--- a/lib/Chart.svelte
+++ b/lib/Chart.svelte
@@ -1,5 +1,5 @@
 <script>
-    import { onMount, tick } from 'svelte';
+    import { onMount, afterUpdate, tick } from 'svelte';
     import BlocksRegion from './BlocksRegion.svelte';
     import Headline from './blocks/Headline.svelte';
     import Description from './blocks/Description.svelte';
@@ -161,18 +161,6 @@
         });
     }
 
-    async function checkHeightAndRender() {
-        if (globalThis.__dw) {
-            const currentHeight = __dw.vis.size()[1];
-            await tick();
-            /* check after tick to get the new values after browser had time for layout and paint */
-            const newHeight = getMaxChartHeight(document.querySelector('.dw-chart-body'));
-            if (currentHeight !== newHeight) {
-                __dw.render();
-            }
-        }
-    }
-
     let regions;
     $: {
         // build all the region
@@ -190,8 +178,6 @@
             belowFooter: getBlocks(allBlocks, 'belowFooter', { chart, data, theme, isStyleStatic }),
             afterBody: getBlocks(allBlocks, 'afterBody', { chart, data, theme, isStyleStatic })
         };
-
-        checkHeightAndRender();
     }
 
     // plain style means no header and footer
@@ -310,6 +296,20 @@ Please make sure you called __(key) with a key of type "string".
             render(data);
         }
     });
+
+    async function checkHeightAndRender() {
+        if (globalThis.__dw) {
+            const currentHeight = __dw.vis.size()[1];
+            await tick();
+            /* check after tick to get the new values after browser had time for layout and paint */
+            const newHeight = getMaxChartHeight(document.querySelector('.dw-chart-body'));
+            if (currentHeight !== newHeight) {
+                __dw.render();
+            }
+        }
+    }
+
+    afterUpdate(checkHeightAndRender);
 </script>
 
 <svelte:head>

--- a/lib/Chart.svelte
+++ b/lib/Chart.svelte
@@ -177,6 +177,10 @@
             belowFooter: getBlocks(allBlocks, 'belowFooter', { chart, data, theme, isStyleStatic }),
             afterBody: getBlocks(allBlocks, 'afterBody', { chart, data, theme, isStyleStatic })
         };
+
+        if (globalThis.__dw) {
+            __dw.render();
+        }
     }
 
     // plain style means no header and footer


### PR DESCRIPTION
Fixes a bug where height calculations wouldn't trigger again when text flows to another line, increasing the elements height.

![height](https://user-images.githubusercontent.com/5798652/80355961-0be1f700-8879-11ea-9470-1e6d197beac1.gif)

`__dw.render` is called in a reactive block every time props change. If there is a better implementation please let me know.