### PR TITLE
Add header id

### DIFF
--- a/lib/BlocksRegion.svelte
+++ b/lib/BlocksRegion.svelte
@@ -1,12 +1,13 @@
 <script>
     import { clean } from './shared';
 
+    export let id;
     export let name;
     export let blocks;
 </script>
 
 {#if blocks.length}
-    <div class={name}>
+    <div {id} class={name}>
         {#each blocks as block}
             <div class="block {block.id}-block" class:export-text={block.exportText}>
                 {#if block.prepend}

--- a/lib/Chart.svelte
+++ b/lib/Chart.svelte
@@ -304,7 +304,7 @@ Please make sure you called __(key) with a key of type "string".
 </svelte:head>
 
 {#if !isStylePlain}
-    <BlocksRegion name="dw-chart-header" blocks={regions.header} />
+    <BlocksRegion name="dw-chart-header" blocks={regions.header} id="header" />
 {/if}
 
 <div id="chart" class="dw-chart-body" />


### PR DESCRIPTION
We have several visualization types that rely on chart header (`div.dw-chart-header`) having an id value of `header`. From what I can see, it gets used at least in `locator-maps`, `visualization-columns-charts` and `visualization-pie-chart`.

This PR adds the ability to add id to `BlockRegion` and adds the id `header` to chart header.