### PR TITLE
remove legacy code + ensure __dw.init is only callled once

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -141,8 +141,12 @@ function initResizeHandler(vis, container) {
     }
 }
 
+let initialized = false;
+
 const __dw = {
     init: function(params) {
+        if (initialized) return;
+        initialized = true;
         __dw.params = params;
         __dw.old_attrs = params.chartJSON;
         domReady(() => {

--- a/lib/render.js
+++ b/lib/render.js
@@ -145,10 +145,6 @@ const __dw = {
     init: function(params) {
         __dw.params = params;
         __dw.old_attrs = params.chartJSON;
-        if (!getVis().checkBrowserCompatibility()) {
-            window.location.href = 'static.html';
-            return;
-        }
         domReady(() => {
             const postEvent = PostEvent(params.chartJSON.id);
             window.addEventListener('hashchange', () => {


### PR DESCRIPTION
* we don't generate `static.html` fallback versions for like 6 years :joy: 
* for some reason `__dw.init` is called twice on every load. not sure if this is the ideal fix (might be worth checking what code is calling it)