### PR TITLE
Remove dataset.reset function

### DIFF
--- a/lib/dw/dataset/index.js
+++ b/lib/dw/dataset/index.js
@@ -10,7 +10,6 @@ export default function(columns) {
     // make column names unique
     let columnsByName = {};
     const origColumns = columns.slice(0);
-    const initialColumns = columns.slice(0);
 
     columns.forEach(col => {
         uniqueName(col);

--- a/lib/dw/dataset/index.js
+++ b/lib/dw/dataset/index.js
@@ -191,19 +191,6 @@ export default function(columns) {
         },
 
         /**
-         * resets the datasets to its original columns
-         * @returns {dw.Dataset}
-         */
-        reset() {
-            columns = initialColumns.slice(0);
-            columnsByName = {};
-            columns.forEach(col => {
-                columnsByName[col.name()] = col;
-            });
-            return dataset;
-        },
-
-        /**
          * cuts each column in the dataset to a maximum number of rows
          * @param {number} numRows
          * @returns {dw.Dataset}


### PR DESCRIPTION
There's a function `dataset.reset` that seems to reset the columns to a prior initial state. While doing that, it seems to delete computed columns that were previously added.

It's not clear to me what the purpose of the function is, and its only occurrence was [removed recently](https://github.com/datawrapper/datawrapper/commit/5da12232ed21d969487645601b45eb39a044e74f). Everything still works as expected (and the 'missing computed column' bug was fixed). 

Do we need this function?