### PR TITLE
Remove use of and reference to exportText block property

### DIFF
--- a/lib/BlocksRegion.svelte
+++ b/lib/BlocksRegion.svelte
@@ -9,7 +9,7 @@
 {#if blocks.length}
     <div {id} class={name}>
         {#each blocks as block}
-            <div class="block {block.id}-block" class:export-text={block.exportText}>
+            <div class="block {block.id}-block">
                 {#if block.prepend}
                     <span class="prepend">
                         {@html clean(block.prepend)}

--- a/lib/Chart.svelte
+++ b/lib/Chart.svelte
@@ -149,9 +149,6 @@
             if (block.component.test) {
                 block.test = block.component.test;
             }
-            if (block.component.exportText) {
-                block.exportText = block.component.exportText;
-            }
             const options = get(theme, 'data.options.blocks', {})[block.id];
             if (!options) return block;
             return {


### PR DESCRIPTION
After discussion with @gka it was decided that we do not need this feature, instead all footer elements should be exported automatically. The required change has been made in export-pdf in this [PR](https://github.com/datawrapper/plugin-export-pdf/pull/109)