### PR TITLE
Use minutely timestamp for datasets on static.dwcdn.net

### DIFF
--- a/lib/dw/dataset/delimited.js
+++ b/lib/dw/dataset/delimited.js
@@ -29,7 +29,7 @@ function delimited(opts) {
 
             const url = `${opts.url}${
                 opts.url.indexOf('?') > -1 ? '&' : '?'
-            }v=${timestamp.getTime()}`;
+            }v=${opts.url.indexOf('//static.dwcdn.net') > -1 ? ts - ts % 60000 : ts}`;
             return window
                 .fetch(url)
                 .then(res => res.text())

--- a/lib/dw/dataset/delimited.js
+++ b/lib/dw/dataset/delimited.js
@@ -20,7 +20,7 @@ import column from './column.js';
 function delimited(opts) {
     function loadAndParseCsv() {
         if (opts.url) {
-            const timestamp = new Date();
+            const ts = new Date().getTime();
             const url = `${opts.url}${
                 opts.url.indexOf('?') > -1 ? '&' : '?'
             }v=${opts.url.indexOf('//static.dwcdn.net') > -1 ? ts - ts % 60000 : ts}`;

--- a/lib/dw/dataset/delimited.js
+++ b/lib/dw/dataset/delimited.js
@@ -20,9 +20,16 @@ import column from './column.js';
 function delimited(opts) {
     function loadAndParseCsv() {
         if (opts.url) {
+            const timestamp = new Date();
+
+            if (opts.url.indexOf('https://static.dwcdn.net') === 0) {
+                timestamp.setSeconds(0);
+                timestamp.setMilliseconds(0);
+            }
+
             const url = `${opts.url}${
                 opts.url.indexOf('?') > -1 ? '&' : '?'
-            }v=${new Date().getTime()}`;
+            }v=${timestamp.getTime()}`;
             return window
                 .fetch(url)
                 .then(res => res.text())

--- a/lib/dw/dataset/delimited.js
+++ b/lib/dw/dataset/delimited.js
@@ -21,12 +21,6 @@ function delimited(opts) {
     function loadAndParseCsv() {
         if (opts.url) {
             const timestamp = new Date();
-
-            if (opts.url.indexOf('https://static.dwcdn.net') === 0) {
-                timestamp.setSeconds(0);
-                timestamp.setMilliseconds(0);
-            }
-
             const url = `${opts.url}${
                 opts.url.indexOf('?') > -1 ? '&' : '?'
             }v=${opts.url.indexOf('//static.dwcdn.net') > -1 ? ts - ts % 60000 : ts}`;


### PR DESCRIPTION
When loading in external data, we include a cache-busting query string to go around both the browser cache and the CDN cache. However, for `static.dwcdn.net` in particular, we know that data updates minutely at most. Going around the cache in these cases is bad for multiple reasons:
- it means worse performance for the user, who needs to get the chart data served from slow S3
- it increases our S3 bills

This PR changes it so that instead of including a query string based on the current millisecond, we only include it for the current _minute_ so Cloudflare & the browser both have a minute to keep it in cache. It's not super nice to have an explicit reference to `static.dwcdn.net` in `chart-core`, though we also have other explicit references to this URL in our codebase, and I'd be fine with it for this change.