### PR TITLE
Use h1 and p as outer block elements

### DIFF
--- a/lib/Block.svelte
+++ b/lib/Block.svelte
@@ -1,0 +1,19 @@
+<script>
+    import { clean } from './shared';
+
+    export let block;
+</script>
+
+{#if block.prepend}
+    <span class="prepend">
+        {@html clean(block.prepend)}
+    </span>
+{/if}
+<span class="block-inner">
+    <svelte:component this={block.component} props={block.props} />
+</span>
+{#if block.append}
+    <span class="append">
+        {@html clean(block.append)}
+    </span>
+{/if}

--- a/lib/BlocksRegion.svelte
+++ b/lib/BlocksRegion.svelte
@@ -1,5 +1,5 @@
 <script>
-    import { clean } from './shared';
+    import Block from './Block.svelte';
 
     export let id;
     export let name;
@@ -9,21 +9,19 @@
 {#if blocks.length}
     <div {id} class={name}>
         {#each blocks as block}
-            <div class="block {block.id}-block">
-                {#if block.prepend}
-                    <span class="prepend">
-                        {@html clean(block.prepend)}
-                    </span>
-                {/if}
-                <span class="block-inner">
-                    <svelte:component this={block.component} props={block.props} />
-                </span>
-                {#if block.append}
-                    <span class="append">
-                        {@html clean(block.append)}
-                    </span>
-                {/if}
-            </div>
+            {#if block.tag === 'h1'}
+                <h1 class="block {block.id}-block">
+                    <Block {block} />
+                </h1>
+            {:else if block.tag === 'p'}
+                <p class="block {block.id}-block">
+                    <Block {block} />
+                </p>
+            {:else}
+                <div class="block {block.id}-block">
+                    <Block {block} />
+                </div>
+            {/if}
         {/each}
     </div>
 {/if}

--- a/lib/Chart.svelte
+++ b/lib/Chart.svelte
@@ -31,6 +31,7 @@
     const coreBlocks = [
         {
             id: 'headline',
+            tag: 'h1',
             region: 'header',
             priority: 10,
             test: ({ chart }) => chart.title && !get(chart, 'metadata.describe.hide-title'),
@@ -38,6 +39,7 @@
         },
         {
             id: 'description',
+            tag: 'p',
             region: 'header',
             priority: 20,
             test: ({ chart }) => get(chart, 'metadata.describe.intro'),

--- a/lib/blocks/Description.svelte
+++ b/lib/blocks/Description.svelte
@@ -8,6 +8,4 @@
     $: description = purifyHtml(get(chart, 'metadata.describe.intro'));
 </script>
 
-<p class="chart-intro">
-    {@html description}
-</p>
+{@html description}

--- a/lib/blocks/Headline.svelte
+++ b/lib/blocks/Headline.svelte
@@ -7,8 +7,4 @@
     $: headline = purifyHtml(chart.title);
 </script>
 
-<h1>
-    <span class="chart-title">
-        {@html headline}
-    </span>
-</h1>
+{@html headline}

--- a/lib/blocks/Notes.svelte
+++ b/lib/blocks/Notes.svelte
@@ -5,6 +5,4 @@
     $: chart = props.chart;
 </script>
 
-<div class="dw-chart-notes">
-    {@html purifyHtml(get(chart, 'metadata.annotate.notes'))}
-</div>
+{@html purifyHtml(get(chart, 'metadata.annotate.notes'))}


### PR DESCRIPTION
This PR removes the need to place `h1` and `p` inside a block, by using it as outer element instead. Since `.block-inner` no longer contains `display:block` elements, this changes how `prepend` and `append` are handled for headline and description:

![image](https://user-images.githubusercontent.com/617518/86449186-56637200-bd07-11ea-8321-3b64a57feac9.png)

**Markup:**

![image](https://user-images.githubusercontent.com/617518/86449291-83b02000-bd07-11ea-8fe5-46e97edf6a81.png)

This will likely need some theme adjustments as `<p class="chart-intro">` and `<span class="chart-title">` no longer exist.