### PR TITLE
Use correct class for notes

### DIFF
--- a/lib/styles.less
+++ b/lib/styles.less
@@ -406,7 +406,7 @@ body {
         border-right: @style_footer_border_right;
     }
 
-    .dw-chart-notes a,
+    .notes-block a,
     .dw-chart-footer a {
         padding: @style_footer_links_padding;
         border-bottom: @style_footer_links_border_bottom;
@@ -420,7 +420,7 @@ body {
         color: @typography_links_color;
     }
 
-    .dw-chart-notes a {
+    .notes-block a {
         font-style: if(
             @typography_notes_cursive = 1,
             italic,
@@ -706,7 +706,7 @@ html[xmlns] .clearfix {
             color: @colors_text;
             color: @typography_footer_color;
         }
-        .dw-chart-notes a {
+        .notes-block a {
             color: @colors_text;
             color: @typography_notes_color;
         }


### PR DESCRIPTION
the `.dw-chart-notes` element was replaced with the `.notes-block` due to the blocks restructuring from [this PR](https://github.com/datawrapper/chart-core/pulls?q=is%3Apr+is%3Aclosed), but one instance of `.dw-chart-notes` got left behind in `styles.less`, this PR fixes that