### PR TITLE
expr-eval parser improvements

### DIFF
--- a/lib/dw/utils/htmlTemplate.js
+++ b/lib/dw/utils/htmlTemplate.js
@@ -3,7 +3,7 @@ import purifyHtml from '@datawrapper/shared/purifyHtml';
 
 const TPL_REG = /\{\{(.+?)\}\}/g;
 const ALLOWED_TAGS =
-    '<a><span><b><br><br/><i><strong><sup><sub><strike><u><em><tt><h1><h2><h3><h4><h5><h6><ul><ol><li><p><table><tr><td><th><tbody><thead><hr>';
+    '<a><div><img><span><b><br><br/><i><strong><sup><sub><strike><u><em><tt><h1><h2><h3><h4><h5><h6><ul><ol><li><p><table><tr><td><th><tbody><thead><hr>';
 /*
  * returns a function that evaluates template strings
  * using `expr-eval`.

--- a/lib/dw/utils/htmlTemplate.test.js
+++ b/lib/dw/utils/htmlTemplate.test.js
@@ -37,3 +37,55 @@ test('evil expr + html', async t => {
     const tpl = htmlTemplate(`{{ col1 }} alert('you are hacked') {{col2}}`);
     t.is(tpl({ col1: '<script>', col2: '</script>' }), " alert('you are hacked') ");
 });
+
+test('cluster tooltips', async t => {
+    const tpl = (tpl, ctx) => {
+        tpl = htmlTemplate(tpl);
+        return tpl(ctx);
+    };
+    const ctx = {
+        symbols: [
+            {
+                ID: 'USA',
+                value: 1234
+            },
+            {
+                ID: 'Canada',
+                value: 1876
+            },
+            {
+                ID: 'Mexico',
+                value: 234
+            }
+        ]
+    };
+    ctx.first = ctx.symbols[0];
+    t.is(tpl(`{{ first.ID }}`, ctx), 'USA');
+    t.is(tpl(`{{ JOIN(PLUCK(symbols, 'ID'), ' and ') }}`, ctx), 'USA and Canada and Mexico');
+    t.is(tpl(`{{ JOIN(PLUCK(symbols, 'ID'), ', ', ' and ') }}`, ctx), 'USA, Canada and Mexico');
+    t.is(
+        tpl(
+            `The countries are {{ JOIN(MAP(f(a) = CONCAT('<b>',a,'</b>'), PLUCK(symbols, 'ID')), ', ', ', and ') }}!`,
+            ctx
+        ),
+        'The countries are <b>USA</b>, <b>Canada</b>, and <b>Mexico</b>!'
+    );
+    t.is(
+        tpl(
+            `There are <b>{{ LENGTH(symbols) }} countries</b> and their names are {{ JOIN(MAP(f(a) = CONCAT('<b>',a,'</b>'), PLUCK(symbols, 'ID')), ', ', ' and ') }}!`,
+            ctx
+        ),
+        'There are <b>3 countries</b> and their names are <b>USA</b>, <b>Canada</b> and <b>Mexico</b>!'
+    );
+    t.is(
+        tpl(
+            `There are <b>{{ LENGTH(symbols) }} countries</b> and their names are {{ JOIN(MAP(f(a) = CONCAT('<b>',a.ID,'</b>'), symbols), ', ', ' and ') }}!`,
+            ctx
+        ),
+        'There are <b>3 countries</b> and their names are <b>USA</b>, <b>Canada</b> and <b>Mexico</b>!'
+    );
+    t.is(
+        tpl(`The biggest value is in <b>{{ (SORT(symbols, FALSE, 'value'))[0].ID }}</b>!`, ctx),
+        'The biggest value is in <b>Canada</b>!'
+    );
+});

--- a/lib/dw/utils/htmlTemplate.test.js
+++ b/lib/dw/utils/htmlTemplate.test.js
@@ -38,6 +38,11 @@ test('evil expr + html', async t => {
     t.is(tpl({ col1: '<script>', col2: '</script>' }), " alert('you are hacked') ");
 });
 
+test('expressions in style attributes', async t => {
+    const tpl = htmlTemplate(`<span style="display:block;width: {{ col1 }}px">foo</span>`);
+    t.is(tpl({ col1: 123 }), '<span style="display:block;width: 123px">foo</span>');
+});
+
 test('cluster tooltips', async t => {
     const tpl = (tpl, ctx) => {
         tpl = htmlTemplate(tpl);

--- a/lib/dw/utils/parser.js
+++ b/lib/dw/utils/parser.js
@@ -219,11 +219,13 @@ export function Parser(options) {
         SPLIT(str, sep) {
             return String(str).split(sep);
         },
-        JOIN(arr, sep) {
+        JOIN(arr, sep, sepLast = null) {
             if (!Array.isArray(arr)) {
                 throw new Error('Second argument to join is not an array');
             }
-            return arr.join(sep);
+            return sepLast
+                ? [arr.slice(0, arr.length - 1).join(sep), arr[arr.length - 1]].join(sepLast)
+                : arr.join(sep);
         },
         // the number of days between two dates
         DATEDIFF(d1, d2) {

--- a/lib/dw/utils/parser.js
+++ b/lib/dw/utils/parser.js
@@ -245,7 +245,7 @@ export function Parser(options) {
 Parser.prototype.parse = function(expr) {
     var instr = [];
     var parserState = new ParserState(this, new TokenStream(this, expr), {
-        allowMemberAccess: false
+        allowMemberAccess: true
     });
 
     parserState.parseExpression(instr);

--- a/lib/dw/utils/parser.js
+++ b/lib/dw/utils/parser.js
@@ -235,6 +235,24 @@ export function Parser(options) {
                 return (a > b ? 1 : a < b ? -1 : 0) * (asc ? 1 : -1);
             });
         },
+        // borrowed from https://github.com/jashkenas/underscore/blob/master/modules/range.js
+        RANGE(start, stop, step) {
+            if (stop == null) {
+                stop = start || 0;
+                start = 0;
+            }
+            if (!step) {
+                step = stop < start ? -1 : 1;
+            }
+
+            const length = Math.max(Math.ceil((stop - start) / step), 0);
+            const range = Array(length);
+
+            for (let idx = 0; idx < length; idx++, start += step) {
+                range[idx] = start;
+            }
+            return range;
+        },
         // the number of days between two dates
         DATEDIFF(d1, d2) {
             d1 = asDate(d1);

--- a/lib/dw/utils/parser.js
+++ b/lib/dw/utils/parser.js
@@ -150,6 +150,15 @@ export function Parser(options) {
             return null;
         }
     };
+    // fallback regular expressions for browsers without
+    // support for the unicode flag //u
+    let PROPER_REGEX = /\w*/g;
+    let TITLE_REGEX = /\w\S*/g;
+
+    try {
+        PROPER_REGEX = new RegExp('\\p{L}*', 'ug');
+        TITLE_REGEX = new RegExp('[\\p{L}\\p{N}]\\S*', 'ug');
+    } catch (e) {}
 
     this.functions = {
         RANDOM: random,
@@ -252,6 +261,24 @@ export function Parser(options) {
                 range[idx] = start;
             }
             return range;
+        },
+        LOWER(str) {
+            return String(str).toLowerCase();
+        },
+        UPPER(str) {
+            return String(str).toUpperCase();
+        },
+        PROPER(str) {
+            return String(str).replace(
+                PROPER_REGEX,
+                txt => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase()
+            );
+        },
+        TITLE(str) {
+            return String(str).replace(
+                TITLE_REGEX,
+                txt => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase()
+            );
         },
         // the number of days between two dates
         DATEDIFF(d1, d2) {

--- a/lib/dw/utils/parser.js
+++ b/lib/dw/utils/parser.js
@@ -37,9 +37,9 @@ import {
     arrayIndex,
     max,
     min,
-    // arrayMap,
-    // arrayFold,
-    // arrayFilter,
+    arrayMap,
+    arrayFold,
+    arrayFilter,
     // stringOrArrayIndexOf,
     // arrayJoin,
     sign,
@@ -160,6 +160,13 @@ export function Parser(options) {
         ATAN2: Math.atan2,
         IF: condition,
         ROUND: roundTo,
+        MAP: arrayMap,
+        FOLD: arrayFold,
+        FILTER: arrayFilter,
+        PLUCK(arr, key) {
+            if (!Array.isArray(arr)) throw new Error('First argument to PLUCK is not an array');
+            return arr.map(item => item[key]);
+        },
         INDEXOF(arr, target) {
             if (!Array.isArray(arr)) arr = String(arr);
             return arr.indexOf(target);

--- a/lib/dw/utils/parser.js
+++ b/lib/dw/utils/parser.js
@@ -227,6 +227,14 @@ export function Parser(options) {
                 ? [arr.slice(0, arr.length - 1).join(sep), arr[arr.length - 1]].join(sepLast)
                 : arr.join(sep);
         },
+        // sort arrays
+        SORT(arr, asc = true, key = null) {
+            return arr.sort((a, b) => {
+                a = typeof key === 'string' ? a[key] : typeof key === 'function' ? key(a) : a;
+                b = typeof key === 'string' ? b[key] : typeof key === 'function' ? key(b) : b;
+                return (a > b ? 1 : a < b ? -1 : 0) * (asc ? 1 : -1);
+            });
+        },
         // the number of days between two dates
         DATEDIFF(d1, d2) {
             d1 = asDate(d1);

--- a/lib/dw/utils/parser.js
+++ b/lib/dw/utils/parser.js
@@ -238,7 +238,7 @@ export function Parser(options) {
         },
         // sort arrays
         SORT(arr, asc = true, key = null) {
-            return arr.sort((a, b) => {
+            return arr.slice(0).sort((a, b) => {
                 a = typeof key === 'string' ? a[key] : typeof key === 'function' ? key(a) : a;
                 b = typeof key === 'string' ? b[key] : typeof key === 'function' ? key(b) : b;
                 return (a > b ? 1 : a < b ? -1 : 0) * (asc ? 1 : -1);

--- a/lib/dw/utils/parser.test.js
+++ b/lib/dw/utils/parser.test.js
@@ -232,6 +232,12 @@ test('TIMEDIFF', t => {
     t.is(parser.evaluate('TIMEDIFF("2020-05-01 10:00:00", "2020-05-01 10:01:00")'), 60);
     t.is(parser.evaluate('TIMEDIFF("2020-05-01 10:00:00", "2020-05-01 12:00:00")'), 7200);
 });
+
+test('custom functions', t => {
+    t.deepEqual(parser.evaluate('f(x) = x > 2; FILTER(f, [1, 2, 0, 3, -1, 5])'), [3, 5]);
+    t.deepEqual(parser.evaluate('FILTER(f(x) = x > 2, [1, 2, 0, 3, -1, 5])'), [3, 5]);
+});
+
 const symbols = [
     {
         ID: 'USA',
@@ -251,4 +257,55 @@ test('PLUCK', t => {
     const ctx = { symbols };
     t.deepEqual(parser.evaluate('PLUCK(symbols, "value")', ctx), [1234, 876, 7390]);
     t.deepEqual(parser.evaluate('PLUCK(symbols, "ID")', ctx), ['USA', 'Canada', 'Mexico']);
+});
+
+test('PLUCK + JOIN', t => {
+    const ctx = { symbols };
+    t.deepEqual(
+        parser.evaluate(`JOIN(PLUCK(symbols, 'ID'), ' and ')`, ctx),
+        'USA and Canada and Mexico'
+    );
+    t.deepEqual(
+        parser.evaluate(`JOIN(PLUCK(symbols, 'ID'), ', ', ' and ')`, ctx),
+        'USA, Canada and Mexico'
+    );
+});
+
+test('PLUCK + MAP + JOIN', t => {
+    const ctx = { symbols };
+    t.deepEqual(
+        parser.evaluate(
+            `JOIN(MAP(f(a) = CONCAT('<b>',a,'</b>'),PLUCK(symbols, 'ID')), ', ', ' and ')`,
+            ctx
+        ),
+        '<b>USA</b>, <b>Canada</b> and <b>Mexico</b>'
+    );
+});
+
+test('SORT', t => {
+    const ctx = { symbols };
+    t.is(parser.evaluate(`(SORT(symbols, FALSE, 'value'))[0].ID`, ctx), 'Mexico');
+    t.is(parser.evaluate(`(SORT(symbols, TRUE, 'value'))[0].ID`, ctx), 'Canada');
+    t.is(parser.evaluate(`(SORT(symbols, TRUE, f(d) = d.value))[0].ID`, ctx), 'Canada');
+    t.is(parser.evaluate(`(PLUCK(SORT(symbols, TRUE, 'value'), 'ID'))[0]`, ctx), 'Canada');
+});
+
+test('RANGE', t => {
+    t.deepEqual(parser.evaluate(`RANGE(5)`), [0, 1, 2, 3, 4]);
+    t.deepEqual(parser.evaluate(`MAP(f(x) = x*x, RANGE(5))`), [0, 1, 4, 9, 16]);
+});
+
+test('UPPER, LOWER, PROPER, TITLE', t => {
+    t.is(parser.evaluate(`UPPER("hellO worLd")`), 'HELLO WORLD');
+    t.is(parser.evaluate(`LOWER("HellO WorLd")`), 'hello world');
+    t.is(parser.evaluate(`PROPER("HellO WorLd")`), 'Hello World');
+    t.is(parser.evaluate(`TITLE("HellO WorLd")`), 'Hello World');
+    t.is(parser.evaluate(`TITLE("2-way street")`), '2-way Street');
+    t.is(parser.evaluate(`PROPER("ämilian der schöpfer")`), 'Ämilian Der Schöpfer');
+    t.is(parser.evaluate(`TITLE("ämilian der schöpfer")`), 'Ämilian Der Schöpfer');
+    t.is(parser.evaluate(`PROPER("baron lloyd-webber")`), 'Baron Lloyd-Webber');
+    t.is(parser.evaluate(`TITLE("baron lloyd-webber")`), 'Baron Lloyd-webber');
+    t.is(parser.evaluate(`PROPER("2-way street")`), '2-Way Street');
+    t.is(parser.evaluate(`PROPER("rgb2csv")`), 'Rgb2Csv');
+    t.is(parser.evaluate(`TITLE("rgb2csv")`), 'Rgb2csv');
 });

--- a/lib/dw/utils/parser.test.js
+++ b/lib/dw/utils/parser.test.js
@@ -232,3 +232,23 @@ test('TIMEDIFF', t => {
     t.is(parser.evaluate('TIMEDIFF("2020-05-01 10:00:00", "2020-05-01 10:01:00")'), 60);
     t.is(parser.evaluate('TIMEDIFF("2020-05-01 10:00:00", "2020-05-01 12:00:00")'), 7200);
 });
+const symbols = [
+    {
+        ID: 'USA',
+        value: 1234
+    },
+    {
+        ID: 'Canada',
+        value: 876
+    },
+    {
+        ID: 'Mexico',
+        value: 7390
+    }
+];
+
+test('PLUCK', t => {
+    const ctx = { symbols };
+    t.deepEqual(parser.evaluate('PLUCK(symbols, "value")', ctx), [1234, 876, 7390]);
+    t.deepEqual(parser.evaluate('PLUCK(symbols, "ID")', ctx), ['USA', 'Canada', 'Mexico']);
+});

--- a/lib/dw/utils/parser.test.js
+++ b/lib/dw/utils/parser.test.js
@@ -300,6 +300,12 @@ test('RANGE', t => {
     t.deepEqual(parser.evaluate(`MAP(f(x) = x*x, RANGE(5))`), [0, 1, 4, 9, 16]);
 });
 
+test('FOLD', t => {
+    t.deepEqual(parser.evaluate(`FOLD(MAX, 0, [0,1,2,3,4,5])`), 5);
+    t.deepEqual(parser.evaluate(`FOLD(MIN, 10, [0,1,2,3,4,5])`), 0);
+    t.deepEqual(parser.evaluate(`FOLD(f(a,b) = a * b, 1, [1,2,3,4,5])`), 120);
+});
+
 test('UPPER, LOWER, PROPER, TITLE', t => {
     t.is(parser.evaluate(`UPPER("hellO worLd")`), 'HELLO WORLD');
     t.is(parser.evaluate(`LOWER("HellO WorLd")`), 'hello world');

--- a/lib/dw/utils/parser.test.js
+++ b/lib/dw/utils/parser.test.js
@@ -290,6 +290,11 @@ test('SORT', t => {
     t.is(parser.evaluate(`(PLUCK(SORT(symbols, TRUE, 'value'), 'ID'))[0]`, ctx), 'Canada');
 });
 
+test('Member-access', t => {
+    const ctx = { symbols };
+    t.is(parser.evaluate(`symbols[0].ID`, ctx), 'USA');
+});
+
 test('RANGE', t => {
     t.deepEqual(parser.evaluate(`RANGE(5)`), [0, 1, 2, 3, 4]);
     t.deepEqual(parser.evaluate(`MAP(f(x) = x*x, RANGE(5))`), [0, 1, 4, 9, 16]);


### PR DESCRIPTION
This PR adds a bunch of utility functions that make our computed columns and tooltip templates more powerful. The reason we need to do this is that we need to support advanced use cases like cluster tooltips.

* allow member access to objects (e.g. `symbols[0].value`) --> 1001657
* add array function `MAP`, `FOLD`, `FILTER` and `PLUCK` --> 17448cf
* add third argument to `JOIN` to support "A, B and C" joining --> 442a6b8
* add convenient `SORT` function for array sorting --> 92c595d
* add `RANGE` function for generating arrays --> f34202e
* add `LOWER`, `UPPER`, `TITLE` and `PROPER` string function for case manipulation --> 02da471
