### PR TITLE
Update datawrapper/shared to get CSRF protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,15 @@
 
 ```
 ├── main.js
-│     - Entry point for rollup to bundle `Chart.svelte` 
+│     - Entry point for rollup to bundle `Chart.svelte`
 │     - (used by datawrapper/api)
 │
 ├── lib
 │     - Directory of source files like `Chart.svelte`
 │     - (used by datawrapper/frontend)
 │
-├── dist  
-│     - Files with global dependencies needed for chart rendering 
+├── dist
+│     - Files with global dependencies needed for chart rendering
 │     - (used by datawrapper/{api,frontend})
 │
 └── vendor
@@ -29,12 +29,18 @@
 
 Above are the interesting files and directories to render charts. Only `lib/` and `dist/` get packaged and published with `npm`.
 
+## API reference
+
+* [Chart](docs/chart.md) ⇒ <code>class</code>
+* [Column](docs/column.md) ⇒ <code>class</code>
+* [Dataset](docs/dataset.md) ⇒ <code>class</code>
+
 ## Development
 
 When changing core functionality it is advised to link a local copy of `@datawrapper/chart-core` in the `datawrapper/api` or `datawrapper/frontend` repositories. Follow these steps to link the package:
 
 ```sh
-~/code/chart-core 
+~/code/chart-core
 ❯  npm link
 
 ~/code/frontend
@@ -46,4 +52,3 @@ Everytime `npm install` is called after that, the link is removed. Usually it is
 ## Publishing
 
 To publish this package run `npm version {major|minor|patch}`  and `npm publish`. To publish you have to be part of the Datawrapper organization on npm.
-

--- a/docs/chart.md
+++ b/docs/chart.md
@@ -1,0 +1,143 @@
+> this documentation is partly outdated
+
+**Chart** is the core class for each Datawrapper chart. The concept of charts and visualizations might be confusing, so please read on to get the idea: A *chart* is an abstract wrapper around the [dataset](Dataset) and the ...
+
+### Initializing charts
+
+```javascript
+var chart = dw.chart(attributes);
+```
+
+### Operating on charts
+
+<a name="chart_get" href="Chart#wiki-chart_get">#</a> chart.<b>get</b>()
+
+Retrieves one of the direct attributes of a chart (such as *id* or *type*) as well as any of the settings stored in the metadata JSON field.
+
+```js
+const { id, title } = chart.get();
+```
+
+<a name="chart_getmetadata" href="Chart#wiki-chart_get">#</a> chart.<b>getMetadata</b>(<i>key</i>, <i>default</i>)
+
+Retrieves a value stored in the metadata JSON field.
+
+```js
+const showHeader = chart.getMetadata('visualize.showHeader', true);
+```
+
+<a name="chart_set" href="Chart#wiki-chart_set">#</a> chart.<b>set</b>(<i>state</i>)
+
+Overrides one of the direct attributes of a chart (such as *id* or *type*) as well as any of the settings stored in the metadata JSON field. Note that the changes are not automatically synchronized with the data model on the server.
+
+```javascript
+chart.set({ type: 'bar-chart' });
+```
+
+In order to synchronize the attributes you need to listen to change events and then update your data source accordingly. In Datawrapper we use [dw.backend.syncChart](Synchronizing charts with UI elements) for that.
+
+<a name="chart_setmetadata" href="Chart#wiki-chart_get">#</a> chart.<b>setMetadata</b>(<i>key</i>, <i>value</i>)
+
+Stores a value in the metadata JSON field.
+
+```js
+chart.setMetadata('visualize.showHeader', false);
+```
+
+
+<a name="chart_onChange" href="Chart#wiki-chart_onChange">#</a> chart.<b>onChange</b>(<i>callback</i>)
+
+Executes the *callback* function every time the chart attributes have been changed.
+
+```javascript
+chart.onChange(function(chart, key, value) {
+   console.log('The value of '+key+' has been changed to '+value);
+});
+chart.set('title', 'Foo');
+// logs "The value of title has been changed to Foo"
+```
+
+<a name="chart_observe" href="Chart#wiki-chart_observe">#</a> chart.<b>observe</b>(<i>callback</i>)
+
+Executes the *callback* function every time the chart attributes have been changed. The difference to *onChange* is that the execution is throttled for 100ms so that several consecutive changes are grouped into one call.
+
+```javascript
+chart.observe(function(chart, changes) {
+   console.log(changes);
+});
+chart.set('title', 'Foo');
+chart.set('type', 'line-chart');
+// logs [{ key: "title", value: "Foo"}, { key: "type", value: "line-chart"}]
+```
+<a name="chart_load" href="Chart#wiki-chart_load">#</a> chart.<b>load</b>([csvData])
+
+Loads the chart data. Uses a [datasource](Datasource) to fetch some data, for instance from a CSV file, and convert it into a [dataset](Dataset). Returns a deferred. If you provide the *csvData* argument it will be used as csv data instead of loading it from file. Note that you can also pass the dataset directly via [chart.dataset()](#chart_dataset).
+
+```javascript
+chart.load().done(function() {
+   // yay, the data has been loaded!
+});
+```
+
+<a name="chart_loaded" href="Chart#wiki-chart_loaded">#</a> chart.<b>loaded</b>(<i>callback</i>)
+
+If the dataset has been loaded already, this will immediately call the *callback* function with the chart as first argument. Otherwise the callback will be kept and executed as soon the dataset has been loaded.
+
+<a name="chart_reload" href="Chart#wiki-chart_reload">#</a> chart.<b>reload</b>()
+
+After a chart has been [loaded](#wiki-chart_load) once, it can be reloaded without having to download the data source again. Returns a deferred.
+
+```javascript
+chart.load().done(function() {
+   // chart has been loaded
+   chart.reload();
+});
+```
+
+<a name="chart_dataset" href="Chart#wiki-chart_dataset">#</a> chart.<b>dataset</b>([<i>dataset</i>])
+
+If called without any argument, this function returns the loaded [dataset](Dataset), including any changes stored in the chart metadata (such as data changes). If you provide the *dataset* argument the function sets it as new chart dataset and returns the chart instance.
+
+```js
+chart.dataset();  // returns the chart dataset
+chart.dataset(ds);  // sets ds as new dataset
+chart.dataset(true);  // returns the chart dataset after re-applying changes, column sorting etc
+```
+
+<a name="chart_theme" href="Chart#wiki-chart_theme">#</a> chart.<b>theme</b>(<i>theme</i>)
+
+Gets or sets the theme.
+
+```javascript
+chart.theme(dw.theme('default'));
+```
+
+<a name="chart_vis" href="Chart#wiki-chart_vis">#</a> chart.<b>vis</b>(<i>visualization</i>)
+
+Gets or sets the visualization.
+
+```javascript
+var lineChart = new Datawrapper.Visualization.LineChart();
+// initialize line chart...
+chart.vis(lineChart);
+```
+
+<a name="chart_columnFormatter" href="Chart#wiki-chart_columnFormatter">#</a> chart.<b>columnFormatter</b>(<i>column</i>)
+
+Returns a function to convert values of a given column into nicely formatted strings. The behavior of the format function usually depends on the column type, the locale, the data input precision and user preferences (as set in descripe step in chart editor).
+
+```javascript
+var dateColumn = chart.dataset().column('TIME'),
+    formatter = chart.columnFormatter(dateColumn);
+
+dateColumn.each(function(date) {
+    console.log(formatter(date));
+});
+```
+
+By default the formatter function uses the short format (the formatted number without prepending and appending any text). To get the long format you need to pass true a second parameter.
+
+```javascript
+formatter(value); // short format, e.g. "12.3"
+formatter(value, true); // long format, e.g. "USD 12.3"
+```  

--- a/docs/column.md
+++ b/docs/column.md
@@ -1,0 +1,82 @@
+**Column** is the base class for data columns (sometimes also called data series) in Datawrapper. A column has a *column type* and stores a list of values as *rows*. Also they support common computations such as calculating the sum and the range of the data it holds.
+
+```js
+import Column from '@datawrapper/chart-core/lib/dw/dataset/column';
+const col = Column('my column', values);
+```
+
+<a name="dw_column" href="Column#wiki-dw_column">#</a> <b>column</b>(<i>name</i>, <i>rows</i>, <i>type</i>)
+
+Instantiates a new column with the name *name* and the data *rows*. Specifying the *type* is optional, if not provided the type will be guessed. Usually you don't need to instantiate columns yourself as they provided by the [dataset](Dataset).
+
+## Operating on columns
+
+<a name="column_name" href="Column#wiki-column_name">#</a> column.<b>name</b>(<i>name</i>)
+
+If called with no arguments, returns the internal name of the column. If you provide the *name* argument, it will be set as new column name. Setting the column name is intended for configuration persistence and should not be used for presentation (use the column.<b>title</b> method for that purpose).
+
+<a name="column_title" href="Column#wiki-column_title">#</a> column.<b>title</b>(<i>title</i>)
+
+If called with no arguments, returns the human-readable title of the column. If the *title* was not set, returns the *name* of the column. If you provide the *title* argument, it will be set as new column title. Setting the column title is intended for presentation.
+
+<a name="column_length" href="Column#wiki-column_length">#</a> column.<b>length</b>
+
+Returns the number of rows in the column.
+
+<a name="column_val" href="Column#wiki-column_val">#</a> column.<b>val</b>(<i>index</i>)
+
+Returns the parsed value in row *index*. The value will be parsed by the [column type](Column#column-types) whenever you call this function. To make our lives easier, you can use negative indexes to get values from the end of the rows, e.g. ``column.val(-1)`` for the last value.
+
+```javascript
+var first = column.val(0);
+var last = column.val(column.length-1);
+// this also works:
+last = column.val(-1);
+```
+
+<a name="column_values" href="Column#wiki-column_values">#</a> column.<b>values</b>()
+
+Returns the parsed values as an array.
+
+<a name="column_each" href="Column#wiki-column_each">#</a> column.<b>each</b>(<i>func</i>)
+
+Applies a function over all parsed values. This invokes a simple for loop over all rows and calls *func* with the arguments *value* and *index*.
+
+```javascript
+sum = 0;
+column.each(function(value, index) {
+   sum += value;
+});
+// note that you can also use this:
+sum = column.total();
+```
+
+<a name="column_type" href="Column#wiki-column_type">#</a> column.<b>type</b>(<i>asObjectorNewType</i>)
+
+If called without an argument **type** returns the column type as string, which would be either *text*, *number* or *date*. If called with *true* as first argument the column type is returned as [object](Column Types). If called with a string as first argument ``type()`` will set a new column type.
+
+```javascript
+datecolumn.type()  // returns column type as string, eg. 'date'
+datecolumn.type(true);  // returns column type as object, eg. dw.column.types.date()
+datecolumn.type('text');  // sets the column type to 'text'
+```
+
+<a name="column_raw" href="Column#wiki-column_raw">#</a> column.<b>raw</b>(<i>row</i>, <i>newValue</i>)
+
+If called without any arguments *raw()* returns an array of all the raw, unparsed values stored in the column. If you provide only the <i>row</i> argument you will only get the raw value of this row. If <i>newValue</i> is also provided the function will set it as new value.
+
+<a name="column_range" href="Column#wiki-column_range">#</a> column.<b>range</b>()
+
+Returns an array with the minimum and maximum of all values in the column. Only works for column types that are convertable to numbers (which is true if they implement the toNum() function).
+
+<a name="column_total" href="Column#wiki-column_total">#</a> column.<b>total</b>()
+
+Returns the sum of all values in the column. Only works for column types that are convertable to numbers (which is true if they implement the toNum() function).
+
+<a name="column_filterRows" href="Column#wiki-column_filterRows">#</a> column.<b>filterRows</b>(<i>indexes</i>)
+
+Temporarily removes all rows whose index is not within the array *indexes*. A copy of the original rows is stored for reference. If called without arguments, ``filterRows`` restores the original rows.
+
+<a name="column_indexOf" href="Column#wiki-column_indexOf">#</a> column.<b>indexOf</b>(<i>value</i>)
+
+Returns the index of the row with given *value* or -1 if the value was not found in the column.

--- a/docs/dataset.md
+++ b/docs/dataset.md
@@ -1,0 +1,71 @@
+**Dataset** is the base class for datasets in Datawrapper. A dataset basically contains of a set of [columns](Column) and provides a few convenient functions.
+
+Datasets are usually constructed by a [data source](Data-Sources).
+
+```javascript
+datasource.dataset().done(function(dataset) {
+    console.log(dataset.columns());
+});
+```
+
+<a name="dw_dataset" href="Dataset#wiki-dw_dataset">#</a> dw.<b>dataset</b>(<i>columns</i>, <i>options</i>)
+
+### Operating on datasets
+
+<a name="dataset_columns" href="Dataset#wiki-dataset_columns">#</a> dataset.<b>columns</b>()
+
+Returns an array of all [columns](Column) in the dataset.
+
+<a name="dataset_column" href="Dataset#wiki-dataset_column">#</a> dataset.<b>column</b>(<i>indexOrName</i>)
+
+Returns the column with the specified *index*. If instead of a Number a string is given, the column with the specified name is returned instead. Will throw an exception if the given column name or index is not found in the dataset.
+
+<a name="dataset_numColumns" href="Dataset#wiki-dataset_numColumns">#</a> dataset.<b>numColumns</b>()
+
+Returns the number of columns.
+
+<a name="dataset_numRows" href="Dataset#wiki-dataset_numRows">#</a> dataset.<b>numRows</b>()
+
+Returns the number of rows of the first column.
+
+<a name="dataset_eachColumn" href="Dataset#wiki-dataset_eachColumn">#</a> dataset.<b>eachColumn</b>(<i>func</i>)
+
+Applies a function over all columns values. This invokes a loop over all columns and calls *func* with the arguments *column* and *index*.
+
+<a name="dataset_eachRow" href="Dataset#wiki-dataset_eachRow">#</a> dataset.<b>eachRow</b>(<i>func</i>)
+
+Applies the function once for all rows in the dataset. This invokes a loop over all rows and calls *func* with the argument *index*.
+
+<a name="dataset_hasColumn" href="Dataset#wiki-dataset_hasColumn">#</a> dataset.<b>hasColumn</b>(<i>indexOrName</i>)
+
+Returns ``true`` if a column with the specified name or index exists. Otherwise returns ``false``.
+
+<a name="dataset_toCSV" href="Dataset#wiki-dataset_toCSV">#</a> dataset.<b>toCSV</b>()
+
+Returns a valid CSV representation of the dataset (as string).
+
+<a name="dataset_filterColumns" href="Dataset#wiki-dataset_filterColumns">#</a> dataset.<b>filterColumns</b>(<i>ignore</i>)
+
+Removes all columns from the dataset whose names are present as keys in the *ignore* object.
+
+```
+// removes the column with the name "UK":
+dataset.filterColumns({ "UK": true });
+```
+
+<a name="dataset_add" href="Dataset#wiki-dataset_add">#</a> dataset.<b>add</b>(<i>column</i>)
+
+Adds a new column to the dataset.
+
+```
+dataset.add(column);
+```
+
+<a name="dataset_reset" href="Dataset#wiki-dataset_reset">#</a> dataset.<b>reset</b>()
+
+Resets the dataset to its initial state. This revokes the effect of preceding calls to *add* or *filterColumns*.
+
+<a name="dataset_list" href="Dataset#wiki-dataset_list">#</a> dataset.<b>list</b>()
+
+Returns the dataset as simple list of JavaScript objects.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@datawrapper/chart-core",
-    "version": "8.17.3",
+    "version": "8.18.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -948,12 +948,13 @@
             "integrity": "sha512-ITYtqMxat9EoOPgGapHIFwSCr9aQBNgU38Rt+G2FgVgcBh2BFoe2sOUMSHyAY/iKmJMQa8RE1bNIRCUIp+stGA=="
         },
         "@datawrapper/shared": {
-            "version": "0.26.2",
-            "resolved": "https://registry.npmjs.org/@datawrapper/shared/-/shared-0.26.2.tgz",
-            "integrity": "sha512-U5ekYqOnSpxuV7YyaOqgaFdlA9F/v1oB8HzbXgbODxCI3kcAR18nibpHoV60gIwm8KpQCP9BxOH8BEVxnvBXpQ==",
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@datawrapper/shared/-/shared-0.27.4.tgz",
+            "integrity": "sha512-8Zns14EMDdm6KFgkwJhvqTNUoMFhO7n9o55EstMk8vVoiyolkBdORL9H82mvmy8YgVbJuEb0vfr+zX4N6almJQ==",
             "requires": {
                 "chroma-js": "^2.0.3",
                 "d3-array": "^1.2.4",
+                "js-cookie": "^2.2.1",
                 "lodash-es": "^4.17.15",
                 "sinon": "^7.3.2",
                 "underscore": "^1.9.1"
@@ -1048,9 +1049,9 @@
             "dev": true
         },
         "@sinonjs/commons": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.0.tgz",
-            "integrity": "sha512-wEj54PfsZ5jGSwMX68G8ZXFawcSglQSXqCftWX3ec8MDUzQdHgcKvw97awHbY0efQEL5iKUOAmmVtoYgmrSG4Q==",
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
+            "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
             "requires": {
                 "type-detect": "4.0.8"
             }
@@ -3233,6 +3234,11 @@
                     }
                 }
             }
+        },
+        "js-cookie": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+            "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
         },
         "js-string-escape": {
             "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@datawrapper/chart-core",
-    "version": "8.17.3",
+    "version": "8.18.3",
     "description": "Svelte component to render charts. Used by Sapper App and Node API.",
     "main": "index.js",
     "files": [
@@ -26,10 +26,10 @@
     },
     "homepage": "https://github.com/datawrapper/chart-core#readme",
     "dependencies": {
-        "@datawrapper/polyfills": "2.0.1",
-        "@datawrapper/shared": "^0.26.2",
-        "core-js": "3.6.5",
         "@datawrapper/expr-eval": "^2.0.2-datawrapper.1",
+        "@datawrapper/polyfills": "2.0.1",
+        "@datawrapper/shared": "^0.27.4",
+        "core-js": "3.6.5",
         "fontfaceobserver": "2.1.0",
         "underscore": "^1.11.0"
     },


### PR DESCRIPTION
#### Motivation

Required by https://github.com/datawrapper/api/pull/215

#### Changes

- Update package.json
- Add documentation for modules moved from datawrapper/shared. See https://github.com/datawrapper/shared/pull/38

#### Remaining issues

- [x] Switch to npm URL once https://github.com/datawrapper/shared/pull/38 is merged and published to npm.