### PR TITLE
Remove references to colors_text, use typography_chart_color instead

### DIFF
--- a/lib/styles.less
+++ b/lib/styles.less
@@ -6,10 +6,12 @@ body {
 }
 
 .chart {
-    font-family: @typography_chart_typeface;
-
     color: @typography_chart_color;
+    text, tspan {
+        fill:@typography_chart_color;
+    }
 
+    font-family: @typography_chart_typeface;
     text-transform: @typography_chart_textTransform;
     letter-spacing: @typography_chart_letterSpacing;
     font-size: @typography_chart_fontSize;

--- a/lib/styles.less
+++ b/lib/styles.less
@@ -8,7 +8,6 @@ body {
 .chart {
     font-family: @typography_chart_typeface;
 
-    color: @colors_text;
     color: @typography_chart_color;
 
     text-transform: @typography_chart_textTransform;
@@ -691,7 +690,6 @@ html[xmlns] .clearfix {
 .static {
     .chart {
         a {
-            color: @colors_text;
             color: @typography_chart_color;
         }
         .dw-chart-header {
@@ -703,11 +701,11 @@ html[xmlns] .clearfix {
             }
         }
         .dw-chart-footer a {
-            color: @colors_text;
+            color: @typography_chart_color;
             color: @typography_footer_color;
         }
         .notes-block a {
-            color: @colors_text;
+            color: @typography_chart_color;
             color: @typography_notes_color;
         }
     }

--- a/lib/styles.less
+++ b/lib/styles.less
@@ -8,7 +8,7 @@ body {
 .chart {
     color: @typography_chart_color;
     text, tspan {
-        fill:@typography_chart_color;
+        fill: @typography_chart_color;
     }
 
     font-family: @typography_chart_typeface;


### PR DESCRIPTION
Will be deprecated, as `typography.chart.color` is now used instead. `colors.text` isn't currently in the theme schema, or in use in any themes.