### PR TITLE
Don't set fill on tspans

### DIFF
--- a/lib/styles.less
+++ b/lib/styles.less
@@ -7,7 +7,7 @@ body {
 
 .chart {
     color: @typography_chart_color;
-    text, tspan {
+    text {
         fill: @typography_chart_color;
     }
 


### PR DESCRIPTION
Added this def so that svg text would get the global main text color but setting it on `tspan` turns out to overwrite the fill applied to the `text` element in annotations, so need to revert that.