### PR TITLE
Add chart.applyDatasetChanges

### DIFF
--- a/lib/dw/chart.js
+++ b/lib/dw/chart.js
@@ -234,6 +234,10 @@ export default function(attributes) {
                 }
             });
             return changed;
+        },
+
+        applyDatasetChanges() {
+            applyChanges(chart, dataset);
         }
     };
 

--- a/lib/dw/svelteChart.js
+++ b/lib/dw/svelteChart.js
@@ -92,6 +92,10 @@ class Chart extends Store {
         return this._dataset;
     }
 
+    applyDatasetChanges() {
+        applyChanges(this, this._dataset);
+    }
+
     // sets or gets the theme
     theme(theme) {
         if (arguments.length) {


### PR DESCRIPTION
This PR adds the method `applyDatasetChanges` to the `chart` object, which causes changes in the metadata (such as cell overrides or column formats) to be re-applied to the dataset object.

This happens already when the dataset is initially loaded, but when the metadata changes subsequently (e.g. by a metadata migration), this method allows the dataset to be explicitly updated again.