### PR TITLE
Fix chart.dataset in svelte chart

### DIFF
--- a/lib/dw/svelteChart.js
+++ b/lib/dw/svelteChart.js
@@ -75,16 +75,11 @@ class Chart extends Store {
         // set a new dataset, or reset the old one if ds===true
         if (arguments.length) {
             if (ds !== true) this._dataset_cache = ds;
-            const jsonData = typeof this._dataset_cache.list !== 'function';
+            else ds = this._dataset_cache;
+            const jsonData = typeof ds.list !== 'function';
             this._dataset = jsonData
                 ? ds
-                : reorderColumns(
-                      this,
-                      applyChanges(
-                          this,
-                          addComputedColumns(this, ds === true ? this._dataset_cache : ds)
-                      )
-                  );
+                : reorderColumns(this, applyChanges(this, addComputedColumns(this, ds)));
             if (jsonData) this.set({ dataset: ds });
             return this._dataset;
         }

--- a/lib/dw/svelteChart.js
+++ b/lib/dw/svelteChart.js
@@ -75,7 +75,7 @@ class Chart extends Store {
         // set a new dataset, or reset the old one if ds===true
         if (arguments.length) {
             if (ds !== true) this._dataset_cache = ds;
-            const jsonData = typeof ds.list !== 'function';
+            const jsonData = typeof this._dataset_cache.list !== 'function';
             this._dataset = jsonData
                 ? ds
                 : reorderColumns(


### PR DESCRIPTION
I think this was an oversight? Checking for `ds` doesn't make sense because it can be `true`