### PR TITLE
Normalize styles across browsers & override font-weight of B element

### DIFF
--- a/lib/styles.less
+++ b/lib/styles.less
@@ -2,6 +2,10 @@
 
 @import (inline) '../node_modules/normalize.css/normalize.css';
 
+html {
+    line-height: 1.2;
+}
+
 body {
     margin: 0;
     padding: 0;

--- a/lib/styles.less
+++ b/lib/styles.less
@@ -8,6 +8,12 @@ body {
     background: @colors_general_background;
 }
 
+b {
+    // We want a B element to always produce 'font-weight: 700', so we need to override the default
+    // 'font-weight: bolder', otherwise a 'font-weight: 300' becomes only 400.
+    font-weight: bold;
+}
+
 .chart {
     color: @typography_chart_color;
 

--- a/lib/styles.less
+++ b/lib/styles.less
@@ -293,9 +293,9 @@ body {
         font-weight: @typography_aboveFooter_fontWeight;
         text-transform: @typography_aboveFooter_textTransform;
         font-size: @typography_aboveFooter_fontSize;
-            & when not (@typography_aboveFooter_lineHeight = __UNDEFINED__) {
-                line-height: @typography_aboveFooter_lineHeight * 1px;
-            }
+        & when not (@typography_aboveFooter_lineHeight = __UNDEFINED__) {
+            line-height: @typography_aboveFooter_lineHeight * 1px;
+        }
         font-style: if(@typography_aboveFooter_cursive = 1, italic, normal);
         text-decoration: if(@typography_aboveFooter_underlined = 1, underline, none);
         color: @typography_aboveFooter_color;
@@ -313,9 +313,9 @@ body {
         font-weight: @typography_notes_fontWeight;
         text-transform: @typography_notes_textTransform;
         font-size: @typography_notes_fontSize;
-            & when not (@typography_notes_lineHeight = __UNDEFINED__) {
-                line-height: @typography_notes_lineHeight * 1px;
-            }
+        & when not (@typography_notes_lineHeight = __UNDEFINED__) {
+            line-height: @typography_notes_lineHeight * 1px;
+        }
         font-style: if(@typography_notes_cursive = 1, italic, normal);
         text-decoration: if(@typography_notes_underlined = 1, underline, none);
         color: @typography_notes_color;
@@ -331,9 +331,9 @@ body {
         font-weight: @typography_belowFooter_fontWeight;
         text-transform: @typography_belowFooter_textTransform;
         font-size: @typography_belowFooter_fontSize;
-            & when not (@typography_belowFooter_lineHeight = __UNDEFINED__) {
-                line-height: @typography_belowFooter_lineHeight * 1px;
-            }
+        & when not (@typography_belowFooter_lineHeight = __UNDEFINED__) {
+            line-height: @typography_belowFooter_lineHeight * 1px;
+        }
         font-style: if(@typography_belowFooter_cursive = 1, italic, normal);
         text-decoration: if(@typography_belowFooter_underlined = 1, underline, none);
         color: @typography_belowFooter_color;
@@ -392,9 +392,9 @@ body {
         font-weight: @typography_footer_fontWeight;
         font-size: @typography_footer_fontSize;
         text-transform: @typography_footer_textTransform;
-            & when not (@typography_footer_lineHeight = __UNDEFINED__) {
-                line-height: @typography_footer_lineHeight * 1px;
-            }
+        & when not (@typography_footer_lineHeight = __UNDEFINED__) {
+            line-height: @typography_footer_lineHeight * 1px;
+        }
         font-style: if(@typography_footer_cursive = 1, italic, normal);
         text-decoration: if(@typography_footer_underlined = 1, underline, none);
         color: @typography_footer_color;
@@ -410,9 +410,9 @@ body {
         border-bottom: @style_footer_links_border_bottom;
         font-family: @typography_links_typeface;
         font-weight: @typography_links_fontWeight;
-            & when not (@typography_links_lineHeight = __UNDEFINED__) {
-                line-height: @typography_links_lineHeight * 1px;
-            }
+        & when not (@typography_links_lineHeight = __UNDEFINED__) {
+            line-height: @typography_links_lineHeight * 1px;
+        }
         font-style: if(@typography_links_cursive = 1, italic, normal);
         text-decoration: if(@typography_links_underlined = 1, underline, nonee);
         color: @typography_links_color;

--- a/lib/styles.less
+++ b/lib/styles.less
@@ -1,4 +1,7 @@
 /* Reference: datawrapper/templates/chart-styles.less.twig */
+
+@import (inline) '../node_modules/normalize.css/normalize.css';
+
 body {
     margin: 0;
     padding: 0;

--- a/lib/styles.less
+++ b/lib/styles.less
@@ -8,7 +8,8 @@ body {
     background: @colors_general_background;
 }
 
-b {
+b,
+strong {
     // We want a B element to always produce 'font-weight: 700', so we need to override the default
     // 'font-weight: bolder', otherwise a 'font-weight: 300' becomes only 400.
     font-weight: bold;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4339,6 +4339,11 @@
             "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
             "dev": true
         },
+        "normalize.css": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
+            "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg=="
+        },
         "npm-run-path": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "@datawrapper/shared": "^0.27.8",
         "core-js": "3.6.5",
         "fontfaceobserver": "2.1.0",
+        "normalize.css": "^8.0.1",
         "svelte-extras": "^2.0.2",
         "svelte2": "npm:svelte@^2.16.1",
         "underscore": "^1.11.0"


### PR DESCRIPTION
#### Motivation

When exporting this Funke table https://app.datawrapper.de/chart/ABElx/publish#export-pdf, the preview doesn't match the result (in neither export format). The **exported chart is higher** so it doesn't fit the document size that the user defined by looking at the preview.

Moreover, in Firefox the text "Malte Stuckmann" doesn't have a **line-break in the preview**, which makes the preview even smaller compared to the result.

Issue: https://www.notion.so/datawrapper/Extra-space-above-and-below-chart-in-export-7acc9b1abcfa41aaac3079962282cb9a

preview:

![Screen Shot 2020-10-22 at 12 45 07](https://user-images.githubusercontent.com/58857807/96861518-7fe60c00-1464-11eb-8688-8c8d52051ea4.png)

export:

![Screen Shot 2020-10-22 at 12 45 15](https://user-images.githubusercontent.com/58857807/96861524-81173900-1464-11eb-89e1-57ddbd6db794.png)

#### Changes

1. **Normalize** the base chart CSS and set a default line-height.

    This slighly changes the text position in almost all charts. The exact difference from previous rendering depends on the browser.

    typical change:

    ![2020-10-22 16-54-05 1870x542](https://user-images.githubusercontent.com/58857807/96889788-3ce96000-1487-11eb-83d1-c9c1a2095725.png)

    one of the largest changes:

    ![2020-10-22 16-50-29 1863x544](https://user-images.githubusercontent.com/58857807/96889824-48d52200-1487-11eb-93d3-fc58ed14140a.png)

2. Change the **default font-weight** of the `B` element so that when the base font has font-weight 300, the `B` makes it 700 (not 400).

    This is the behaviour of Chrome without normalization. We're expecting this behaviour, so let's keep it event after the normalization.

3. To fix the difference in the line break in "Malte Stuckmann" between Firefox and the export (Chrome), we must **turn off kerning**. It seems that Chrome doesn't support kerning for this particular font, so turning it off makes Firefox render the text like Chrome.

    ``` diff
    diff --git a/tests/themes/funke-waz.less b/tests/themes/funke-waz.less
    index cf5cb79..1fdf239 100644
    --- a/tests/themes/funke-waz.less
    +++ b/tests/themes/funke-waz.less
    @@ -35,6 +35,9 @@ h1 {
             url(https://static.dwcdn.net/custom/themes/funke/MetaHeadlinePro.ttf) format('truetype'),
             url(https://static.dwcdn.net/custom/themes/funke/MetaHeadlinePro.svg#MetaHeadlinePro)
                 format('svg');
    +    // Chrome doesn't seem to support kerning for this font, so let's turn it off in Firefox to
    +    // normalize the rendering.
    +    font-feature-settings: 'kern' 0;
     }

     @font-face {
    @@ -46,6 +49,9 @@ h1 {
                 format('truetype'),
             url(https://static.dwcdn.net/custom/themes/funke/MetaHeadlinePro-Bold.svg#MetaHeadlineProBold)
                 format('svg');
    +    // Chrome doesn't seem to support kerning for this font, so let's turn it off in Firefox to
    +    // normalize the rendering.
    +    font-feature-settings: 'kern' 0;
     }

     @font-face {
    @@ -57,4 +63,7 @@ h1 {
                 format('truetype'),
             url(https://static.dwcdn.net/custom/themes/funke/MetaHeadlinePro-Light.svg#MetaHeadlineProLight)
                 format('svg');
    +    // Chrome doesn't seem to support kerning for this font, so let's turn it off in Firefox to
    +    // normalize the rendering.
    +    font-feature-settings: 'kern' 0;
     }
    ```

#### Remaining issues

- [ ] Do the theme change (kerning off) on production.