### PR TITLE
Align svelteChart.js and chart.js more

### DIFF
--- a/lib/Chart.svelte
+++ b/lib/Chart.svelte
@@ -324,7 +324,7 @@ Please make sure you called __(key) with a key of type "string".
             /* check after tick to get the new values after browser had time for layout and paint */
             const newHeight = getMaxChartHeight(document.querySelector('.dw-chart-body'));
             if (currentHeight !== newHeight) {
-                __dw.renderNow();
+                __dw.render();
             }
         }
     }

--- a/lib/Chart.svelte
+++ b/lib/Chart.svelte
@@ -324,7 +324,7 @@ Please make sure you called __(key) with a key of type "string".
             /* check after tick to get the new values after browser had time for layout and paint */
             const newHeight = getMaxChartHeight(document.querySelector('.dw-chart-body'));
             if (currentHeight !== newHeight) {
-                __dw.render();
+                __dw.renderNow();
             }
         }
     }

--- a/lib/dw/svelteChart.js
+++ b/lib/dw/svelteChart.js
@@ -7,6 +7,9 @@ import json from './dataset/json';
 import reorderColumns from './dataset/reorderColumns';
 import applyChanges from './dataset/applyChanges';
 import addComputedColumns from './dataset/addComputedColumns';
+import significantDimension from '@datawrapper/shared/significantDimension';
+import get from '@datawrapper/shared/get';
+import events from './utils/events';
 
 import { put } from '@datawrapper/shared/httpReq';
 import { loadScript } from '@datawrapper/shared/fetch';
@@ -15,7 +18,9 @@ const storeChanges = _.debounce((chart, callback) => {
     const state = chart.serialize();
 
     put(`/v3/charts/${state.id}`, { payload: state })
-        .then(() => {
+        .then(attributes => {
+            console.log('FIRE SAVED', attributes);
+            chart.fire('save', attributes);
             if (callback) callback();
         })
         .catch(e => {
@@ -39,6 +44,9 @@ const storeData = _.debounce((chart, callback) => {
             console.error('Could not store chart data', e);
         });
 }, 1000);
+
+const changeCallbacks = events();
+const datasetChangeCallbacks = events();
 
 class Chart extends Store {
     /*
@@ -148,12 +156,18 @@ class Chart extends Store {
         });
 
         // check if new value is set
-        if (!deepEqual(pt[lastKey], value)) {
+        if (!_.isEqual(pt[lastKey], value)) {
+            console.log('EQUAL?', key, value);
             pt[lastKey] = value;
             this.set({ metadata });
         }
         return this;
     }
+
+    // set(key, value) {
+    //     console.log('SET', key);
+    //     super.set(key, value);
+    // }
 
     // stores the state of this chart to server
     store(callback) {
@@ -162,6 +176,10 @@ class Chart extends Store {
 
     storeData(callback) {
         storeData(this, callback);
+    }
+
+    onChange(c) {
+        changeCallbacks.add(c);
     }
 
     serialize() {
@@ -194,7 +212,27 @@ class Chart extends Store {
         keep.forEach(k => {
             copy[k] = state[k];
         });
+        copy['theme'] = this.get().themeId;
         return copy;
+    }
+
+    columnFormatter(column) {
+        // pull output config from metadata
+        // return column.formatter(config);
+        var colFormat = get(this.get(), 'metadata.data.column-format', {});
+        colFormat = _.clone(colFormat[column.name()] || { type: 'auto', 'number-format': 'auto' });
+
+        if (
+            column.type() === 'number' &&
+            (colFormat === 'auto' ||
+                colFormat['number-format'] === undefined ||
+                colFormat['number-format'] === 'auto')
+        ) {
+            var values = column.values();
+            var dim = significantDimension(values);
+            colFormat['number-format'] = 'n' + Math.max(0, dim);
+        }
+        return column.type(true).formatter(colFormat);
     }
 
     passiveMode() {
@@ -214,10 +252,6 @@ class Chart extends Store {
 Chart.prototype.observeDeep = observeDeep;
 
 export default Chart;
-
-function deepEqual(a, b) {
-    return JSON.stringify(a) === JSON.stringify(b);
-}
 
 function loadGlobalizeLocale(locale, callback) {
     if (Object.prototype.hasOwnProperty.call(window.Globalize.cultures, locale)) {

--- a/lib/dw/svelteChart.js
+++ b/lib/dw/svelteChart.js
@@ -44,9 +44,6 @@ const storeData = _.throttle((chart, callback) => {
         });
 }, 1000);
 
-const changeCallbacks = events();
-const datasetChangeCallbacks = events();
-
 class Chart extends Store {
     /*
      * load a csv or json dataset
@@ -169,10 +166,6 @@ class Chart extends Store {
 
     storeData(callback) {
         storeData(this, callback);
-    }
-
-    onChange(c) {
-        changeCallbacks.add(c);
     }
 
     serialize() {

--- a/lib/dw/svelteChart.js
+++ b/lib/dw/svelteChart.js
@@ -14,12 +14,11 @@ import events from './utils/events';
 import { put } from '@datawrapper/shared/httpReq';
 import { loadScript } from '@datawrapper/shared/fetch';
 
-const storeChanges = _.debounce((chart, callback) => {
+const storeChanges = _.throttle((chart, callback) => {
     const state = chart.serialize();
 
     put(`/v3/charts/${state.id}`, { payload: state })
         .then(attributes => {
-            console.log('FIRE SAVED', attributes);
             chart.fire('save', attributes);
             if (callback) callback();
         })
@@ -28,7 +27,7 @@ const storeChanges = _.debounce((chart, callback) => {
         });
 }, 1000);
 
-const storeData = _.debounce((chart, callback) => {
+const storeData = _.throttle((chart, callback) => {
     const data = chart.getMetadata('data.json') ? JSON.stringify(chart.dataset()) : chart.rawData();
     // const data = chart.rawData();
     put(`/v3/charts/${chart.get().id}/data`, {
@@ -157,17 +156,11 @@ class Chart extends Store {
 
         // check if new value is set
         if (!_.isEqual(pt[lastKey], value)) {
-            console.log('EQUAL?', key, value);
             pt[lastKey] = value;
             this.set({ metadata });
         }
         return this;
     }
-
-    // set(key, value) {
-    //     console.log('SET', key);
-    //     super.set(key, value);
-    // }
 
     // stores the state of this chart to server
     store(callback) {
@@ -212,7 +205,6 @@ class Chart extends Store {
         keep.forEach(k => {
             copy[k] = state[k];
         });
-        copy['theme'] = this.get().themeId;
         return copy;
     }
 

--- a/lib/dw/svelteChart.js
+++ b/lib/dw/svelteChart.js
@@ -77,6 +77,17 @@ class Chart extends Store {
             });
     }
 
+    transpose() {
+        const { metadata } = this.get();
+        const transpose = (metadata.data.transpose = !metadata.data.transpose);
+        const firstRowIsHeader = metadata.data['horizontal-header'];
+        delimited({ firstRowIsHeader, transpose, csv: this.dataset().csv() })
+            .dataset()
+            .then(dataset => {
+                this.set({ dataset, metadata });
+            });
+    }
+
     // sets or returns the dataset
     dataset(ds) {
         // set a new dataset, or reset the old one if ds===true

--- a/lib/dw/svelteChart.js
+++ b/lib/dw/svelteChart.js
@@ -77,17 +77,6 @@ class Chart extends Store {
             });
     }
 
-    transpose() {
-        const { metadata } = this.get();
-        const transpose = (metadata.data.transpose = !metadata.data.transpose);
-        const firstRowIsHeader = metadata.data['horizontal-header'];
-        delimited({ firstRowIsHeader, transpose, csv: this.dataset().csv() })
-            .dataset()
-            .then(dataset => {
-                this.set({ dataset, metadata });
-            });
-    }
-
     // sets or returns the dataset
     dataset(ds) {
         // set a new dataset, or reset the old one if ds===true

--- a/lib/dw/visualization.base.js
+++ b/lib/dw/visualization.base.js
@@ -151,12 +151,6 @@ _.extend(base, {
             function checkColumn(col) {
                 return !usedColumns[col.name()] && _.indexOf(axisDef.accepts, col.type()) >= 0;
             }
-            function errMissingColumn() {
-                var msg = dw.backend
-                    ? dw.backend.messages.insufficientData
-                    : 'The visualization needs at least one column of the type %type to populate axis %key';
-                errors.push(msg.replace('%type', axisDef.accepts).replace('%key', key));
-            }
             function remainingRequiredColumns(accepts) {
                 // returns how many required columns there are for the remaining axes
                 // either an integer or "multiple" if there's another multi-column axis coming up
@@ -252,8 +246,6 @@ _.extend(base, {
                                 usedColumns[col.name()] = true;
                                 axes[key] = col.name();
                             }
-                        } else {
-                            errMissingColumn();
                         }
                     }
                 } else {
@@ -272,10 +264,6 @@ _.extend(base, {
                             available--;
                         }
                     });
-
-                    if (!axes[key].length) {
-                        errMissingColumn();
-                    }
                 }
             } else {
                 axes[key] = false;

--- a/lib/dw/visualization.base.js
+++ b/lib/dw/visualization.base.js
@@ -9,6 +9,7 @@
 import _ from 'underscore';
 import column from './dataset/column';
 import { remove } from './utils';
+import get from '@datawrapper/shared/get';
 
 const base = function() {}.prototype;
 
@@ -33,7 +34,11 @@ _.extend(base, {
     },
 
     theme(theme) {
-        if (!arguments.length) return this.__theme;
+        if (!arguments.length) {
+            if (typeof this.__theme === 'string') return dw.theme(this.__theme);
+            return this.__theme;
+        }
+
         this.__theme = theme;
         const attrProperties = ['horizontalGrid', 'verticalGrid', 'yAxis', 'xAxis'];
         _.each(attrProperties, function(prop) {
@@ -63,7 +68,7 @@ _.extend(base, {
      * short-cut for this.chart.get('metadata.visualize.*')
      */
     get(str, _default) {
-        return this.chart().get('metadata.visualize' + (str ? '.' + str : ''), _default);
+        return get(this.chart().get(), 'metadata.visualize' + (str ? '.' + str : ''), _default);
     },
 
     notify(str) {
@@ -103,7 +108,7 @@ _.extend(base, {
         me.dataset = chart.dataset();
         me.theme(chart.theme());
         me.__chart = chart;
-        var columnFormat = chart.get('metadata.data.column-format', {});
+        var columnFormat = get(chart.get(), 'metadata.data.column-format', {});
         var ignore = {};
         _.each(columnFormat, function(format, key) {
             ignore[key] = !!format.ignore;
@@ -125,7 +130,7 @@ _.extend(base, {
         const errors = [];
 
         // get user preference
-        const userAxes = me.chart().get('metadata.axes', {});
+        const userAxes = get(me.chart().get(), 'metadata.axes', {});
         _.each(me.meta.axes, (o, key) => {
             if (userAxes[key]) {
                 let columns = userAxes[key];
@@ -195,7 +200,7 @@ _.extend(base, {
                 // chart settings may override this
                 if (
                     axisDef.overrideOptionalKey &&
-                    me.chart().get('metadata.' + axisDef.overrideOptionalKey, false)
+                    get(me.chart().get(), 'metadata.' + axisDef.overrideOptionalKey, false)
                 ) {
                     // now the axis is mandatory
                     axisDef.optional = false;

--- a/lib/render.js
+++ b/lib/render.js
@@ -119,7 +119,7 @@ function renderLater() {
     clearTimeout(reloadTimer);
     reloadTimer = setTimeout(function() {
         renderChart();
-    }, 50);
+    }, 100);
 }
 
 function initResizeHandler(vis, container) {

--- a/lib/render.js
+++ b/lib/render.js
@@ -206,12 +206,12 @@ export default function render({
         );
 
         observeFonts(fontsJSON, typographyJSON)
-            .then(() => __dw.renderNow())
-            .catch(() => __dw.renderNow());
+            .then(() => __dw.render())
+            .catch(() => __dw.render());
 
         // iPhone/iPad fix
         if (/iP(hone|od|ad)/.test(navigator.platform)) {
-            window.onload = __dw.renderNow();
+            window.onload = __dw.render();
         }
 
         let themeFitChart = false;

--- a/lib/render.js
+++ b/lib/render.js
@@ -119,7 +119,7 @@ function renderLater() {
     clearTimeout(reloadTimer);
     reloadTimer = setTimeout(function() {
         renderChart();
-    }, 300);
+    }, 50);
 }
 
 function initResizeHandler(vis, container) {
@@ -206,12 +206,12 @@ export default function render({
         );
 
         observeFonts(fontsJSON, typographyJSON)
-            .then(() => __dw.render())
-            .catch(() => __dw.render());
+            .then(() => __dw.renderNow())
+            .catch(() => __dw.renderNow());
 
         // iPhone/iPad fix
         if (/iP(hone|od|ad)/.test(navigator.platform)) {
-            window.onload = __dw.render();
+            window.onload = __dw.renderNow();
         }
 
         let themeFitChart = false;


### PR DESCRIPTION
In the new visualize app, we initialize a `visualization` object with `svelteChart.js` class instead of the `chart.js` class used during rendering. To make this work, a few things needed to be changed in the visualization classes (mostly no longer using `vis.get('some.key')` which doesn't exist in the svelte store), and the `columnFormatter` method had to be added to `svelteChart.js`