### PR TITLE
Be a bit smarter about column assignments

### DIFF
--- a/lib/dw/visualization.base.js
+++ b/lib/dw/visualization.base.js
@@ -134,8 +134,8 @@ _.extend(base, {
         _.each(me.meta.axes, (o, key) => {
             if (userAxes[key]) {
                 let columns = userAxes[key];
-                if (columnExists(columns)) {
-                    axes[key] = columns;
+                if (columnExists(columns) && checkColumn(o, columns)) {
+                    axes[key] = o.multiple && !_.isArray(columns) ? [columns] : columns;
                     // mark columns as used
                     if (!_.isArray(columns)) columns = [columns];
                     _.each(columns, function(column) {
@@ -148,9 +148,6 @@ _.extend(base, {
         var checked = [];
         // auto-populate remaining axes
         _.each(me.meta.axes, (axisDef, key) => {
-            function checkColumn(col) {
-                return !usedColumns[col.name()] && _.indexOf(axisDef.accepts, col.type()) >= 0;
-            }
             function remainingRequiredColumns(accepts) {
                 // returns how many required columns there are for the remaining axes
                 // either an integer or "multiple" if there's another multi-column axis coming up
@@ -182,7 +179,7 @@ _.extend(base, {
             function remainingAvailableColumns(dataset, i) {
                 let count = 0;
                 dataset.eachColumn((c, index) => {
-                    if (checkColumn(c)) {
+                    if (checkColumn(axisDef, c)) {
                         count++;
                     }
                 });
@@ -203,7 +200,7 @@ _.extend(base, {
             if (!axisDef.optional) {
                 // we only populate mandatory axes
                 if (!axisDef.multiple) {
-                    const accepted = _.filter(dataset.columns(), checkColumn);
+                    const accepted = _.filter(dataset.columns(), c => checkColumn(axisDef, c));
                     let firstMatch;
                     if (axisDef.preferred) {
                         // axis defined a regex for testing column names
@@ -258,7 +255,7 @@ _.extend(base, {
                         if (required === 'multiple' && axes[key].length) return;
                         else if (available <= required) return;
 
-                        if (checkColumn(c)) {
+                        if (checkColumn(axisDef, c)) {
                             usedColumns[c.name()] = true;
                             axes[key].push(c.name());
                             available--;
@@ -294,6 +291,20 @@ _.extend(base, {
             if (!_.isArray(columns)) columns = [columns];
             for (var i = 0; i < columns.length; i++) {
                 if (!dataset.hasColumn(columns[i])) return false;
+            }
+            return true;
+        }
+
+        function checkColumn(axisDef, columns) {
+            if (!_.isArray(columns)) columns = [columns];
+            columns = columns.map(el => (typeof el === 'string' ? dataset.column(el) : el));
+            for (var i = 0; i < columns.length; i++) {
+                if (
+                    usedColumns[columns[i].name()] ||
+                    _.indexOf(axisDef.accepts, columns[i].type()) === -1
+                ) {
+                    return false;
+                }
             }
             return true;
         }


### PR DESCRIPTION
In the old visualize UI, Datawrapper would not fill the `metadata.axes` object unless the user explicitly changed the value. This means that you could open a dataset as a column chart (which gets assigned a text column for the `x` axis), and then switch to a scatter plot (which gets a date/number column for the `x` axis), and it would work seamlessly.

The new svelte controls persist every automatically assigned axis->column selection to the metadata, due to the way Svelte works. This means that after the column chart gets a text column assigned as `x`, when switching to a scatter plot, the line chart would also get that text column in return when calling `vis.axes().x`.

this breaks various things in both the render code and the controls when axes columns aren't what the visualization expects. to make it work, i changed the axis assignment code a bit. in the past, any column found in `metadata.axes` was deemed valid as long as it existed in the dataset. now, the type is checked (so we don't match incorrect column types), and also if an axis defines `multiple` columns, we turn `metadata.axes.y: "colname"` into `metadata.axes.y: ["colname"]`. 