### PR TITLE
Don't use axisCache when user preferences changed

### DIFF
--- a/lib/dw/visualization.base.js
+++ b/lib/dw/visualization.base.js
@@ -136,7 +136,7 @@ _.extend(base, {
         _.each(me.meta.axes, (o, key) => {
             if (userAxes[key]) {
                 let columns = userAxes[key];
-                if (columnExists(columns) && checkColumn(o, columns)) {
+                if (columnExists(columns) && checkColumn(o, columns, true)) {
                     axes[key] = o.multiple && !_.isArray(columns) ? [columns] : columns;
                     // mark columns as used
                     if (!_.isArray(columns)) columns = [columns];
@@ -298,12 +298,12 @@ _.extend(base, {
             return true;
         }
 
-        function checkColumn(axisDef, columns) {
+        function checkColumn(axisDef, columns, allowMultipleUse) {
             if (!_.isArray(columns)) columns = [columns];
             columns = columns.map(el => (typeof el === 'string' ? dataset.column(el) : el));
             for (var i = 0; i < columns.length; i++) {
                 if (
-                    usedColumns[columns[i].name()] ||
+                    (!allowMultipleUse && usedColumns[columns[i].name()]) ||
                     _.indexOf(axisDef.accepts, columns[i].type()) === -1
                 ) {
                     return false;

--- a/lib/dw/visualization.base.js
+++ b/lib/dw/visualization.base.js
@@ -10,6 +10,7 @@ import _ from 'underscore';
 import column from './dataset/column';
 import { remove } from './utils';
 import get from '@datawrapper/shared/get';
+import clone from '@datawrapper/shared/clone';
 
 const base = function() {}.prototype;
 
@@ -119,7 +120,9 @@ _.extend(base, {
 
     axes(returnAsColumns, noCache) {
         const me = this;
-        if (!noCache && me.__axisCache) {
+        const userAxes = get(me.chart().get(), 'metadata.axes', {});
+
+        if (!noCache && me.__axisCache && _.isEqual(me.__axisCache.userAxes, userAxes)) {
             return me.__axisCache[returnAsColumns ? 'axesAsColumns' : 'axes'];
         }
 
@@ -130,7 +133,6 @@ _.extend(base, {
         const errors = [];
 
         // get user preference
-        const userAxes = get(me.chart().get(), 'metadata.axes', {});
         _.each(me.meta.axes, (o, key) => {
             if (userAxes[key]) {
                 let columns = userAxes[key];
@@ -287,7 +289,8 @@ _.extend(base, {
 
         me.__axisCache = {
             axes: axes,
-            axesAsColumns: axesAsColumns
+            axesAsColumns: axesAsColumns,
+            userAxes: clone(userAxes)
         };
 
         function columnExists(columns) {


### PR DESCRIPTION
We use a state property `me.__axisCache` to not recompute axis assignments every time some part of the code calls `vis.axes`. This PR changes it so that we _don't_ use that cache if `metadata.axes` changed since the last time the assignments were run.