### PR TITLE
Don't turn single column selection into multiple

### DIFF
--- a/lib/dw/visualization.base.js
+++ b/lib/dw/visualization.base.js
@@ -136,7 +136,11 @@ _.extend(base, {
         _.each(me.meta.axes, (o, key) => {
             if (userAxes[key]) {
                 let columns = userAxes[key];
-                if (columnExists(columns) && checkColumn(o, columns, true)) {
+                if (
+                    columnExists(columns) &&
+                    checkColumn(o, columns, true) &&
+                    !!o.multiple === _.isArray(columns)
+                ) {
                     axes[key] = o.multiple && !_.isArray(columns) ? [columns] : columns;
                     // mark columns as used
                     if (!_.isArray(columns)) columns = [columns];


### PR DESCRIPTION
This PR fixes an unintended side effect by the [recent PR](https://github.com/datawrapper/chart-core/pull/61). This changes it so that we don't turn this column selection in the `metadata`:

```
axes: {
    y: "Value"
}
```

into 

```
axes: {
    y: [ "Value" ]
}
```

when the requesting visualization defines that the axis is eligible for `multiple` columns. Otherwise, a user could switch to a scatter plot, select an individual column as their y, and then switch back to the line chart, and get only that single column visualized (rather than all numerical columns, which is what our line chart does). Instead, we treat such metadata settings as invalid and refer to the default behavior, so it works the same as before.