### PR TITLE
Add font weight css for ticks

### DIFF
--- a/lib/styles.less
+++ b/lib/styles.less
@@ -487,14 +487,14 @@ body {
         font-family: @style_chart_labels_ticks_secondary_typeface;
         font-size: @style_chart_labels_ticks_secondary_fontSize;
 
-        color: @style_chart_labels_ticks_secondary_color;
         color: @style_chart_labels_ticks_color;
+        color: @style_chart_labels_ticks_secondary_color;
 
-        fill: @style_chart_labels_ticks_secondary_color;
         fill: @style_chart_labels_ticks_color;
+        fill: @style_chart_labels_ticks_secondary_color;
 
-        font-weight: @style_chart_labels_ticks_secondary_fontWeight;
         font-weight: @style_chart_labels_ticks_fontWeight;
+        font-weight: @style_chart_labels_ticks_secondary_fontWeight;
     }
 
     .primary.tick {
@@ -516,6 +516,9 @@ body {
 
             fill: @style_chart_labels_ticks_color;
             fill: @style_chart_labels_ticks_primary_color;
+
+            font-weight: @style_chart_labels_ticks_fontWeight;
+            font-weight: @style_chart_labels_ticks_primary_fontWeight;
         }
     }
 

--- a/lib/styles.less
+++ b/lib/styles.less
@@ -492,6 +492,9 @@ body {
 
         fill: @style_chart_labels_ticks_secondary_color;
         fill: @style_chart_labels_ticks_color;
+
+        font-weight: @style_chart_labels_ticks_secondary_fontWeight;
+        font-weight: @style_chart_labels_ticks_fontWeight;
     }
 
     .primary.tick {


### PR DESCRIPTION
Schema PR [here](https://github.com/datawrapper/schemas/pull/39). Also corrected the order of priority for the other tick font props.