### PR TITLE
Prevent render issues due to chart dimensions being invalid

### DIFF
--- a/lib/dw/utils/index.js
+++ b/lib/dw/utils/index.js
@@ -79,9 +79,10 @@ export function name(obj) {
 }
 
 export function getMaxChartHeight() {
+    if (window.innerHeight === 0) return 0;
     var maxH = window.innerHeight - 8;
     maxH -= getNonChartHeight();
-    return maxH;
+    return Math.max(maxH, 0);
 }
 
 export function nearest(array, value) {
@@ -125,11 +126,13 @@ export function logTicks(min, max) {
 /* globals getComputedStyle */
 
 export function height(element) {
-    return parseFloat(getComputedStyle(element, null).height.replace('px', ''));
+    const h = parseFloat(getComputedStyle(element, null).height.replace('px', ''));
+    return isNaN(h) ? 0 : h;
 }
 
 export function width(element) {
-    return parseFloat(getComputedStyle(element, null).width.replace('px', ''));
+    const w = parseFloat(getComputedStyle(element, null).width.replace('px', ''));
+    return isNaN(w) ? 0 : w;
 }
 
 export function addClass(element, className) {

--- a/lib/render.js
+++ b/lib/render.js
@@ -87,8 +87,8 @@ function renderChart() {
         }
     }
 
-    // only render if iframe is visible and has valid dimensions
-    if (window.innerWidth > 0 && window.innerHeight > 0) {
+    // only render if iframe has valid dimensions
+    if (vis.meta.height === 'fixed' ? w > 0 : w > 0 && h > 0) {
         chart.render($chart);
     }
 }

--- a/lib/render.js
+++ b/lib/render.js
@@ -54,6 +54,7 @@ function renderChart() {
         vis = __dw.vis = getVis();
         chart.vis(vis);
     }
+
     vis.size(w, h);
 
     initResizeHandler(vis, $chart);

--- a/lib/render.js
+++ b/lib/render.js
@@ -54,7 +54,6 @@ function renderChart() {
         vis = __dw.vis = getVis();
         chart.vis(vis);
     }
-
     vis.size(w, h);
 
     initResizeHandler(vis, $chart);
@@ -87,7 +86,10 @@ function renderChart() {
         }
     }
 
-    chart.render($chart);
+    // only render if iframe is visible and has valid dimensions
+    if (window.innerWidth > 0 && window.innerHeight > 0) {
+        chart.render($chart);
+    }
 }
 
 function getHeight(sel) {


### PR DESCRIPTION
### Motivation
When the iframe **width or height is 0**, e.g:
- if it is embedded without the `height` attribute
- if it is initially set as `display:none` (e.g hidden behind a toggle)
Attempts to render can cause problems in some chart types that use SVG or Canvas, which rely on dimensions to work properly.

Some more details can be found in [this ticket](https://www.notion.so/datawrapper/Maps-embedded-initially-display-none-don-t-render-in-Firefox-and-look-funny-in-chrome-909231be91f044f38c9a939b3ca30f07).

Notably, when an iframe isn't visible, it has height & width = 0, however the `w` & `h` of the `$chart` that get passed to the vis are `NaN` and `-8` respectively, which naturally cause problems during render. These weird dimensions are actually just a side effect of the functions used to measure the dimensions:

**Width:**
https://github.com/datawrapper/chart-core/blob/2376484498a6a9ac5289090f561e990cbc679661/lib/dw/utils/index.js#L131-L133

**Height:**
https://github.com/datawrapper/chart-core/blob/fff5e82904aec16b49216f6b7941ab7ee3d27fcd/lib/dw/utils/index.js#L81-L85

### Changes
Altered these functions to never return 'garbage' values (NaN, or < 0) which are what cause follow-on errors in various forms in various render codes.

Only try to render charts under specific conditions:
**Fixed height:** `w > 0` (they only need a width, which then determines the height)
**Fit height:** `h > 0 && w > 0`

**Tested this in all scenarios that I figured made sense:**
- Fixed height charts (maps & pies)
- Fit height charts (scatters)
- Chrome, Firefox, IE
- Chart rendered initially display:none
- Chart rendered initially heightless
- Chart rendered with initial height insufficient to accommodate non-chart elements & chart body

Charts render in all combination permutations of the above, and don't throw errors.