### PR TITLE
Prepend 'get the data' CSV with BOM to ensure proper encoding when opening in excel

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -81,7 +81,8 @@ function renderChart() {
                 dataLink.setAttribute('download', 'data-' + chart.get('id') + '.csv');
                 dataLink.setAttribute(
                     'href',
-                    'data:application/octet-stream;charset=utf-8,' + encodeURIComponent(csv)
+                    'data:application/octet-stream;charset=utf-8,' +
+                        encodeURIComponent('\uFEFF' + csv)
                 );
             }
         }


### PR DESCRIPTION
Otherwise CSVs open in excel with the wrong encoding, and look like this:
![image](https://user-images.githubusercontent.com/19191012/100226417-025c6280-2f20-11eb-8dda-b9a246423d18.png)

Ticket [here](https://www.notion.so/datawrapper/Get-the-data-encoding-issue-627bbe02deca49f585a67afdda0616d0).