### PR TITLE
Display menu when configured in theme

### DIFF
--- a/lib/Chart.svelte
+++ b/lib/Chart.svelte
@@ -1,6 +1,7 @@
 <script>
     import { onMount, afterUpdate, tick } from 'svelte';
     import BlocksRegion from './BlocksRegion.svelte';
+    import Menu from './Menu.svelte';
     import Headline from './blocks/Headline.svelte';
     import Description from './blocks/Description.svelte';
     import Source from './blocks/Source.svelte';
@@ -198,7 +199,8 @@
             }),
             footerRight: getBlocks(allBlocks, 'footerRight', { chart, data, theme, isStyleStatic }),
             belowFooter: getBlocks(allBlocks, 'belowFooter', { chart, data, theme, isStyleStatic }),
-            afterBody: getBlocks(allBlocks, 'afterBody', { chart, data, theme, isStyleStatic })
+            afterBody: getBlocks(allBlocks, 'afterBody', { chart, data, theme, isStyleStatic }),
+            menu: getBlocks(allBlocks, 'menu', { chart, data, theme, isStyleStatic })
         };
     }
 
@@ -343,6 +345,8 @@ Please make sure you called __(key) with a key of type "string".
 
 {#if !isStylePlain}
     <BlocksRegion name="dw-chart-header" blocks={regions.header} id="header" />
+
+    <Menu name="dw-chart-menu" blocks={regions.menu} />
 {/if}
 
 <div id="chart" class="dw-chart-body" />

--- a/lib/Chart.svelte
+++ b/lib/Chart.svelte
@@ -346,7 +346,9 @@ Please make sure you called __(key) with a key of type "string".
 {#if !isStylePlain}
     <BlocksRegion name="dw-chart-header" blocks={regions.header} id="header" />
 
-    <Menu name="dw-chart-menu" blocks={regions.menu} />
+    {#if !isStyleStatic}
+        <Menu name="dw-chart-menu" blocks={regions.menu} />
+    {/if}
 {/if}
 
 <div id="chart" class="dw-chart-body" />

--- a/lib/Menu.svelte
+++ b/lib/Menu.svelte
@@ -55,12 +55,13 @@
         z-index: 1;
     }
 
-    :global(.menu-content > .dw-chart-menu > *) {
+    :global(.menu-content > .dw-chart-menu > a) {
         padding: 10px;
+        display: block;
         border-bottom: 1px solid #ccc;
     }
 
-    :global(.menu-content > .dw-chart-menu > *:last-child) {
+    :global(.menu-content > .dw-chart-menu > a:last-child) {
         border-bottom: none;
     }
 </style>

--- a/lib/Menu.svelte
+++ b/lib/Menu.svelte
@@ -68,11 +68,11 @@
 <svelte:window on:click={hide} />
 
 {#if blocks.length}
-    <div class="menu qtip" on:click|stopPropagation={toggle}>
+    <div class="menu tooltip" on:click|stopPropagation={toggle}>
         <div />
     </div>
 
-    <div class="menu-content qtip" on:click|stopPropagation class:hidden={!open}>
+    <div class="menu-content tooltip" on:click|stopPropagation class:hidden={!open}>
         <BlocksRegion {id} {name} {blocks} />
     </div>
 {/if}

--- a/lib/Menu.svelte
+++ b/lib/Menu.svelte
@@ -55,13 +55,17 @@
         z-index: 1;
     }
 
-    :global(.menu-content > .dw-chart-menu > a) {
+    :global(.menu-content > .dw-chart-menu a) {
         padding: 10px;
         display: block;
         border-bottom: 1px solid #ccc;
     }
 
-    :global(.menu-content > .dw-chart-menu > a:last-child) {
+    :global(.menu-content > .dw-chart-menu a:hover) {
+        background: rgba(0, 0, 0, 0.05);
+    }
+
+    :global(.menu-content > .dw-chart-menu .block:last-child a) {
         border-bottom: none;
     }
 </style>

--- a/lib/Menu.svelte
+++ b/lib/Menu.svelte
@@ -23,16 +23,16 @@
         position: absolute;
         top: 0px;
         right: 0px;
-        margin: 10px 10px 3px 3px;
-        width: 20px;
-        padding: 5px 0px;
+        margin: 4px 10px 3px 3px;
+        width: 18px;
+        padding: 3px 0px;
 
-        border-top: 1px solid black;
-        border-bottom: 1px solid black;
+        border-top: 2px solid black;
+        border-bottom: 2px solid black;
     }
 
     .menu div {
-        height: 1px;
+        height: 2px;
         width: 100%;
         background: black;
     }
@@ -48,16 +48,18 @@
 
     .menu-content {
         position: absolute;
-        top: 40px;
-        right: 0px;
+        top: 30px;
+        right: 4px;
         background: white;
         border: 1px solid #ccc;
         z-index: 1;
+        box-shadow: 0px 0px 4px 1px rgba(0, 0, 0, 0.1);
     }
 
     :global(.menu-content > .dw-chart-menu a) {
         padding: 10px;
         display: block;
+        color: initial;
         border-bottom: 1px solid #ccc;
     }
 

--- a/lib/Menu.svelte
+++ b/lib/Menu.svelte
@@ -1,0 +1,78 @@
+<script>
+    import BlocksRegion from './BlocksRegion.svelte';
+
+    export let id;
+    export let name;
+    export let blocks;
+
+    let open = false;
+
+    function toggle() {
+        open = !open;
+    }
+
+    function hide() {
+        open = false;
+    }
+</script>
+
+<style>
+    .menu {
+        cursor: pointer;
+
+        position: absolute;
+        top: 0px;
+        right: 0px;
+        margin: 10px 10px 3px 3px;
+        width: 20px;
+        padding: 5px 0px;
+
+        border-top: 1px solid black;
+        border-bottom: 1px solid black;
+    }
+
+    .menu div {
+        height: 1px;
+        width: 100%;
+        background: black;
+    }
+
+    .menu:hover {
+        border-top-color: #ccc;
+        border-bottom-color: #ccc;
+    }
+
+    .menu:hover div {
+        background: #ccc;
+    }
+
+    .menu-content {
+        position: absolute;
+        top: 40px;
+        right: 0px;
+        background: white;
+        border: 1px solid #ccc;
+        z-index: 1;
+    }
+
+    :global(.menu-content > .dw-chart-menu > *) {
+        padding: 10px;
+        border-bottom: 1px solid #ccc;
+    }
+
+    :global(.menu-content > .dw-chart-menu > *:last-child) {
+        border-bottom: none;
+    }
+</style>
+
+<svelte:window on:click={hide} />
+
+{#if blocks.length}
+    <div class="menu qtip" on:click|stopPropagation={toggle}>
+        <div />
+    </div>
+
+    <div class="menu-content qtip" on:click|stopPropagation class:hidden={!open}>
+        <BlocksRegion {id} {name} {blocks} />
+    </div>
+{/if}


### PR DESCRIPTION
To display chart actions in a collapsible menu, see [ticket](https://www.notion.so/datawrapper/In-chart-menu-to-access-various-download-features-CSV-PNG-e64e1d5bb7af4e7ebd304492271661c7)