### PR TITLE
Always re-render visualization when height changes in fitchart mode

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -89,7 +89,7 @@ function renderChart() {
     }
 
     // only render if iframe has valid dimensions
-    if (vis.meta.height === 'fixed' ? w > 0 : w > 0 && h > 0) {
+    if (getHeightMode() === 'fixed' ? w > 0 : w > 0 && h > 0) {
         chart.render($chart);
     }
 }
@@ -98,6 +98,18 @@ function getHeight(sel) {
     const el = document.querySelector(sel);
     if (!el) return 0;
     return height(el);
+}
+
+function getHeightMode() {
+    const vis = __dw.params.visJSON;
+    const theme = dw.theme(__dw.params.themeId);
+    const themeFitChart =
+        get(theme, 'vis.d3-pies.fitchart', false) &&
+        ['d3-pies', 'd3-donuts', 'd3-multiple-pies', 'd3-multiple-donuts'].indexOf(vis.id) > -1;
+    const urlParams = new URLSearchParams(window.location.search);
+    const urlFitChart = !!urlParams.get('fitchart');
+
+    return themeFitChart || urlFitChart || visJSON.height !== 'fixed' ? 'fit' : 'fixed';
 }
 
 function chartLoaded() {
@@ -127,8 +139,7 @@ function renderLater() {
 }
 
 function initResizeHandler(vis, container) {
-    const height = vis.meta.height || 'fit';
-    const resize = height === 'fixed' ? resizeFixed : renderLater;
+    const resize = getHeightMode() === 'fixed' ? resizeFixed : renderLater;
     let curWidth = width(container);
 
     // IE continuosly reloads the chart for some strange reasons
@@ -218,26 +229,9 @@ export default function render({
             window.onload = __dw.render();
         }
 
-        let themeFitChart = false;
-        const visType = visJSON.id;
-        const theme = dw.theme(themeId);
-        if (theme && visType) {
-            const isPies =
-                visType === 'd3-pies' ||
-                visType === 'd3-donuts' ||
-                visType === 'd3-multiple-pies' ||
-                visType === 'd3-multiple-donuts';
-            if (isPies) {
-                themeFitChart = get(theme, 'vis.d3-pies.fitchart', 0);
-            }
-        }
-        const urlParams = new URLSearchParams(window.location.search);
-        const isFitChart =
-            urlParams.get('fitchart') === '1' || themeFitChart === 1 || themeFitChart === true;
-
         setInterval(function() {
             let desiredHeight;
-            if (visJSON.height === 'fixed' && !isFitChart) {
+            if (getHeightMode() === 'fixed') {
                 desiredHeight = outerHeight(document.querySelector('html'), true);
             } else {
                 if (__dw.params.preview || !__dw.vis.chart().get('metadata.publish.chart-height')) {


### PR DESCRIPTION
There are multiple ways to make sure a chart renders in `fitchart` mode (`fitchart` querystring parameter, theme option, visualization meta).

However, three checks for whether `fitchart` is true in `render.js` were implemented inconsistently. This lead to a bug where re-rendering didn't occur when the height changed in `fitchart` mode (e.g. in PDF export preview). This is fixed now. The logic itself has not been changed in this PR.

A related improvement would be to then pass this value to the visualization's `render` function, so they don't have to make this check themselves again in the render code.