### PR TITLE
Purify chart title in <head></head> completely

### DIFF
--- a/lib/Chart.svelte
+++ b/lib/Chart.svelte
@@ -344,7 +344,7 @@ Please make sure you called __(key) with a key of type "string".
 </script>
 
 <svelte:head>
-    <title>{chart.title}</title>
+    <title>{purifyHtml(chart.title, '')}</title>
     <meta name="description" content={get(chart, 'metadata.describe.intro')} />
     {@html `<${'style'}>${customCSS}</style>`}
     {#if publishData.chartAfterHeadHTML}


### PR DESCRIPTION
Otherwise some html winds up visible in some 3rd party share modals. See [ticket](https://www.notion.so/datawrapper/Remove-HTML-tags-from-og-title-property-in-meta-tag-9bd64c7c6f3e4a76a1d1acef23086fdc).

![image](https://user-images.githubusercontent.com/19191012/104012283-d3d4d700-51af-11eb-9d81-05339bc957e4.png)