### PR TITLE
Remove bom before csv parsing

### DIFF
--- a/lib/dw/dataset/delimited.js
+++ b/lib/dw/dataset/delimited.js
@@ -83,7 +83,7 @@ class DelimitedParser {
         const closure = opts.delimiter !== '|' ? '|' : '#';
         let arrData;
 
-        data = closure + '\n' + data.replace(/[ \r\n\f]+$/g, '') + closure;
+        data = closure + '\n' + data.replace(/[ \r\n\f]+$/g, '').replace(/^\uFEFF/gm, '') + closure;
 
         function parseCSV(delimiterPattern, strData, strDelimiter) {
             // implementation and regex borrowed from:

--- a/lib/dw/dataset/delimited.js
+++ b/lib/dw/dataset/delimited.js
@@ -83,7 +83,7 @@ class DelimitedParser {
         const closure = opts.delimiter !== '|' ? '|' : '#';
         let arrData;
 
-        data = closure + '\n' + data.replace(/[ \r\n\f]+$/g, '').replace(/^\uFEFF/gm, '') + closure;
+        data = closure + '\n' + data.replace(/[ \r\n\f]+$/g, '').replace(/^\uFEFF/, '') + closure;
 
         function parseCSV(delimiterPattern, strData, strDelimiter) {
             // implementation and regex borrowed from:


### PR DESCRIPTION
I encountered a bug with CSVs where the BOM prevented the first cell to be interpreted by Datawrapper correctly. This PR strips the BOM from the dataset before parsing.

More details in [Notion ticket](https://www.notion.so/datawrapper/CSV-with-BOM-is-parsed-incorrectly-12d961bb7a074ee5a29ea85e590307de)

Maybe there are other solutions and/or maybe there's a way to do it together with the other regex that is already run?