### PR TITLE
allow more tags in chart description (to support tables)

### DIFF
--- a/lib/blocks/Description.svelte
+++ b/lib/blocks/Description.svelte
@@ -4,8 +4,11 @@
     const { get, purifyHtml } = props;
     $: chart = props.chart;
 
+    const allowedTags =
+        '<a><span><b><br><br/><i><strong><sup><sub><strike><u><em><tt><table><thead><tbody><tfoot><caption><colgroup><col><tr><td><th>';
+
     // internal props
-    $: description = purifyHtml(get(chart, 'metadata.describe.intro'));
+    $: description = purifyHtml(get(chart, 'metadata.describe.intro'), allowedTags);
 </script>
 
 {@html description}


### PR DESCRIPTION
some of our users want to include tables in the chart description