### PR TITLE
Make chart resizing independent of window, improve general event handling

### DIFF
--- a/lib/dw/chart.js
+++ b/lib/dw/chart.js
@@ -1,9 +1,9 @@
 import _ from 'underscore';
+import { on, fire } from 'svelte2/shared';
 import get from '@datawrapper/shared/get';
 import set from '@datawrapper/shared/set';
 import significantDimension from '@datawrapper/shared/significantDimension';
-import columnNameToVariable from '@datawrapper/shared/columnNameToVariable';
-import column from './dataset/column';
+
 import json from './dataset/json';
 import delimited from './dataset/delimited';
 import { name } from './utils';
@@ -21,6 +21,9 @@ export default function(attributes) {
     let theme;
     let metricPrefix;
     let locale;
+
+    // I believe these are no longer in use anywhere.
+    // TODO: Clarify & remove
     const changeCallbacks = events();
     const datasetChangeCallbacks = events();
 
@@ -189,8 +192,13 @@ export default function(attributes) {
             return attributes;
         },
 
-        onChange: changeCallbacks.add,
+        // Super-simple event handling, borrowed from Svelte 2:
+        _handlers: {},
+        on,
+        fire,
 
+        // Legacy event-handling (TODO: Remove/replace?):
+        onChange: changeCallbacks.add,
         onDatasetChange: datasetChangeCallbacks.add,
 
         columnFormatter(column) {

--- a/lib/dw/chart.js
+++ b/lib/dw/chart.js
@@ -1,5 +1,4 @@
 import _ from 'underscore';
-import { on, fire } from 'svelte2/shared';
 import get from '@datawrapper/shared/get';
 import set from '@datawrapper/shared/set';
 import significantDimension from '@datawrapper/shared/significantDimension';
@@ -191,11 +190,6 @@ export default function(attributes) {
             }
             return attributes;
         },
-
-        // Super-simple event handling, borrowed from Svelte 2:
-        _handlers: {},
-        on,
-        fire,
 
         // Legacy event-handling (TODO: Remove/replace?):
         onChange: changeCallbacks.add,

--- a/lib/dw/visualization.base.js
+++ b/lib/dw/visualization.base.js
@@ -416,7 +416,7 @@ _.extend(base, {
      * fire a custom vis event
      */
     fire(eventType, data) {
-        if (this.__callbacks[eventType]) {
+        if (this.__callbacks && this.__callbacks[eventType]) {
             this.__callbacks[eventType].forEach(function(cb) {
                 if (typeof cb === 'function') cb(data);
             });

--- a/lib/dw/visualization.base.js
+++ b/lib/dw/visualization.base.js
@@ -8,7 +8,7 @@
 
 import _ from 'underscore';
 import column from './dataset/column';
-import { remove, getMaxChartHeight } from './utils';
+import { remove } from './utils';
 import get from '@datawrapper/shared/get';
 import clone from '@datawrapper/shared/clone';
 
@@ -401,9 +401,6 @@ _.extend(base, {
     colorsUsed() {
         return Object.keys(this.__colors);
     },
-
-    // TODO: Implement getMaxChartHeight in a way that does not rely on `window`
-    getMaxChartHeight,
 
     /**
      * register an event listener for custom vis events

--- a/lib/dw/visualization.base.js
+++ b/lib/dw/visualization.base.js
@@ -8,7 +8,7 @@
 
 import _ from 'underscore';
 import column from './dataset/column';
-import { remove } from './utils';
+import { remove, getMaxChartHeight } from './utils';
 import get from '@datawrapper/shared/get';
 import clone from '@datawrapper/shared/clone';
 
@@ -401,6 +401,9 @@ _.extend(base, {
     colorsUsed() {
         return Object.keys(this.__colors);
     },
+
+    // TODO: Implement getMaxChartHeight in a way that does not rely on `window`
+    getMaxChartHeight,
 
     /**
      * register an event listener for custom vis events

--- a/lib/render.js
+++ b/lib/render.js
@@ -17,6 +17,7 @@ import {
 import get from '@datawrapper/shared/get';
 import PostEvent from '@datawrapper/shared/postEvent';
 import observeFonts from '@datawrapper/shared/observeFonts';
+import _defer from 'underscore/modules/defer';
 
 let chart, reloadTimer;
 
@@ -132,34 +133,29 @@ function getVis() {
 }
 
 function renderLater() {
-    clearTimeout(reloadTimer);
-    reloadTimer = setTimeout(function() {
-        renderChart();
-    }, 100);
+    _defer(renderChart)();
 }
 
 function initResizeHandler(chart, container) {
-    const resizeHandler = getHeightMode() === 'fixed' ? resizeFixed : resize;
-    let curWidth = width(container);
+    let currentWidth = width(container);
 
-    // TODO: Use an approach that has no side-effects instead of this:
-    // IE continuosly reloads the chart for some strange reasons
-    if (navigator.userAgent.match(/msie/i) === null) {
-        window.onresize = resizeHandler;
-    }
-
-    function resize() {
+    const resize = () => {
         chart.fire('resize');
         renderLater();
-    }
+    };
 
-    function resizeFixed() {
+    const resizeFixed = () => {
         const w = width(container);
-        if (curWidth !== w) {
-            curWidth = w;
+        if (currentWidth !== w) {
+            currentWidth = w;
             resize();
         }
-    }
+    };
+
+    const fixedHeight = getHeightMode() === 'fixed';
+    const resizeHandler = fixedHeight ? resizeFixed : resize;
+    const resizeObserver = new ResizeObserver(resizeHandler);
+    resizeObserver.observe(container.parentElement);
 }
 
 let initialized = false;

--- a/lib/render.js
+++ b/lib/render.js
@@ -17,9 +17,8 @@ import {
 import get from '@datawrapper/shared/get';
 import PostEvent from '@datawrapper/shared/postEvent';
 import observeFonts from '@datawrapper/shared/observeFonts';
-import _ from 'underscore';
 
-let chart, $chart;
+let chart, $chart, reloadTimer;
 
 function renderChart() {
     if (__dw.vis && !__dw.vis.supportsSmartRendering()) {
@@ -132,7 +131,10 @@ function getVis() {
 }
 
 function renderLater() {
-    _.defer(renderChart);
+    clearTimeout(reloadTimer);
+    reloadTimer = setTimeout(function() {
+        renderChart();
+    }, 100);
 }
 
 function initResizeHandler() {

--- a/lib/render.js
+++ b/lib/render.js
@@ -17,7 +17,7 @@ import {
 import get from '@datawrapper/shared/get';
 import PostEvent from '@datawrapper/shared/postEvent';
 import observeFonts from '@datawrapper/shared/observeFonts';
-import _defer from 'underscore/modules/defer';
+import _ from 'underscore';
 
 let chart, reloadTimer;
 
@@ -133,7 +133,7 @@ function getVis() {
 }
 
 function renderLater() {
-    _defer(renderChart)();
+    _.defer(renderChart);
 }
 
 function initResizeHandler(chart, container) {
@@ -154,8 +154,13 @@ function initResizeHandler(chart, container) {
 
     const fixedHeight = getHeightMode() === 'fixed';
     const resizeHandler = fixedHeight ? resizeFixed : resize;
-    const resizeObserver = new ResizeObserver(resizeHandler);
-    resizeObserver.observe(container.parentElement);
+
+    if ('ResizeObserver' in window) {
+        const resizeObserver = new ResizeObserver(resizeHandler);
+        resizeObserver.observe(container.parentElement);
+    } else {
+        window.addEventListener('resize', resizeHandler);
+    }
 }
 
 let initialized = false;

--- a/lib/render.js
+++ b/lib/render.js
@@ -153,13 +153,7 @@ function initResizeHandler() {
 
     const fixedHeight = getHeightMode() === 'fixed';
     const resizeHandler = fixedHeight ? resizeFixed : resize;
-
-    if ('ResizeObserver' in window) {
-        const resizeObserver = new ResizeObserver(resizeHandler);
-        resizeObserver.observe($chart.parentElement);
-    } else {
-        window.addEventListener('resize', resizeHandler);
-    }
+    window.addEventListener('resize', resizeHandler);
 }
 
 let initialized = false;

--- a/lib/render.js
+++ b/lib/render.js
@@ -19,7 +19,7 @@ import PostEvent from '@datawrapper/shared/postEvent';
 import observeFonts from '@datawrapper/shared/observeFonts';
 import _ from 'underscore';
 
-let chart, reloadTimer;
+let chart, $chart;
 
 function renderChart() {
     if (__dw.vis && !__dw.vis.supportsSmartRendering()) {
@@ -28,7 +28,6 @@ function renderChart() {
         // reset and remove it
         __dw.vis.reset();
     }
-    const $chart = document.querySelector('.dw-chart-body');
 
     const belowChartHeight =
         getHeight('.dw-chart-footer') +
@@ -91,8 +90,6 @@ function renderChart() {
     if (getHeightMode() === 'fixed' ? w > 0 : w > 0 && h > 0) {
         chart.render($chart);
     }
-
-    initResizeHandler(chart, $chart);
 }
 
 function getHeight(sel) {
@@ -136,8 +133,8 @@ function renderLater() {
     _.defer(renderChart);
 }
 
-function initResizeHandler(chart, container) {
-    let currentWidth = width(container);
+function initResizeHandler() {
+    let currentWidth = width($chart);
 
     const resize = () => {
         chart.fire('resize');
@@ -145,7 +142,7 @@ function initResizeHandler(chart, container) {
     };
 
     const resizeFixed = () => {
-        const w = width(container);
+        const w = width($chart);
         if (currentWidth !== w) {
             currentWidth = w;
             resize();
@@ -157,7 +154,7 @@ function initResizeHandler(chart, container) {
 
     if ('ResizeObserver' in window) {
         const resizeObserver = new ResizeObserver(resizeHandler);
-        resizeObserver.observe(container.parentElement);
+        resizeObserver.observe($chart.parentElement);
     } else {
         window.addEventListener('resize', resizeHandler);
     }
@@ -177,6 +174,8 @@ const __dw = {
                 postEvent('hash.change', { hash: window.location.hash });
             });
             chartLoaded().then(renderChart);
+            $chart = document.querySelector('.dw-chart-body');
+            initResizeHandler();
         });
     },
     render: renderLater,

--- a/lib/render.js
+++ b/lib/render.js
@@ -57,8 +57,6 @@ function renderChart() {
 
     vis.size(w, h);
 
-    initResizeHandler(vis, $chart);
-
     // update data link to point to edited dataset
     const csv = chart.dataset().toCSV && chart.dataset().toCSV();
     if (!csv || (csv && csv.trim && csv.trim() === 'X.1')) {
@@ -92,6 +90,8 @@ function renderChart() {
     if (getHeightMode() === 'fixed' ? w > 0 : w > 0 && h > 0) {
         chart.render($chart);
     }
+
+    initResizeHandler(chart, $chart);
 }
 
 function getHeight(sel) {
@@ -138,20 +138,26 @@ function renderLater() {
     }, 100);
 }
 
-function initResizeHandler(vis, container) {
-    const resize = getHeightMode() === 'fixed' ? resizeFixed : renderLater;
+function initResizeHandler(chart, container) {
+    const resizeHandler = getHeightMode() === 'fixed' ? resizeFixed : resize;
     let curWidth = width(container);
 
+    // TODO: Use an approach that has no side-effects instead of this:
     // IE continuosly reloads the chart for some strange reasons
     if (navigator.userAgent.match(/msie/i) === null) {
-        window.onresize = resize;
+        window.onresize = resizeHandler;
+    }
+
+    function resize() {
+        chart.fire('resize');
+        renderLater();
     }
 
     function resizeFixed() {
         const w = width(container);
         if (curWidth !== w) {
             curWidth = w;
-            renderLater();
+            resize();
         }
     }
 }

--- a/lib/render.js
+++ b/lib/render.js
@@ -141,7 +141,7 @@ function initResizeHandler() {
     let currentWidth = width($chart);
 
     const resize = () => {
-        chart.fire('resize');
+        chart.vis().fire('resize');
         renderLater();
     };
 

--- a/lib/render.js
+++ b/lib/render.js
@@ -19,9 +19,11 @@ import PostEvent from '@datawrapper/shared/postEvent';
 import observeFonts from '@datawrapper/shared/observeFonts';
 import _ from 'underscore';
 
-let chart, $chart;
+let chart;
 
 function renderChart() {
+    const $chart = document.querySelector('.dw-chart-body');
+
     if (__dw.vis && !__dw.vis.supportsSmartRendering()) {
         // a current visualization exists but it is not smart
         // enough to re-render itself properly, so we need to
@@ -134,6 +136,7 @@ function renderLater() {
 }
 
 function initResizeHandler() {
+    const $chart = document.querySelector('.dw-chart-body');
     let currentWidth = width($chart);
 
     const resize = () => {
@@ -173,9 +176,12 @@ const __dw = {
             window.addEventListener('hashchange', () => {
                 postEvent('hash.change', { hash: window.location.hash });
             });
-            chartLoaded().then(renderChart);
-            $chart = document.querySelector('.dw-chart-body');
-            initResizeHandler();
+            chartLoaded().then(chart => {
+                // TODO: Some charts go blank when resize is triggered. Why is that happening?
+                // TODO: Pass `chart` through to rendering/initialization
+                renderChart();
+                initResizeHandler();
+            });
         });
     },
     render: renderLater,

--- a/lib/render.js
+++ b/lib/render.js
@@ -22,14 +22,14 @@ import _ from 'underscore';
 let chart;
 
 function renderChart() {
-    const $chart = document.querySelector('.dw-chart-body');
-
     if (__dw.vis && !__dw.vis.supportsSmartRendering()) {
         // a current visualization exists but it is not smart
         // enough to re-render itself properly, so we need to
         // reset and remove it
         __dw.vis.reset();
     }
+
+    const $chart = document.querySelector('.dw-chart-body');
 
     const belowChartHeight =
         getHeight('.dw-chart-footer') +

--- a/lib/render.js
+++ b/lib/render.js
@@ -19,7 +19,7 @@ import PostEvent from '@datawrapper/shared/postEvent';
 import observeFonts from '@datawrapper/shared/observeFonts';
 import _ from 'underscore';
 
-let chart;
+let chart, $chart;
 
 function renderChart() {
     if (__dw.vis && !__dw.vis.supportsSmartRendering()) {
@@ -29,7 +29,7 @@ function renderChart() {
         __dw.vis.reset();
     }
 
-    const $chart = document.querySelector('.dw-chart-body');
+    $chart = document.querySelector('.dw-chart-body');
 
     const belowChartHeight =
         getHeight('.dw-chart-footer') +
@@ -136,7 +136,6 @@ function renderLater() {
 }
 
 function initResizeHandler() {
-    const $chart = document.querySelector('.dw-chart-body');
     let currentWidth = width($chart);
 
     const resize = () => {
@@ -176,9 +175,7 @@ const __dw = {
             window.addEventListener('hashchange', () => {
                 postEvent('hash.change', { hash: window.location.hash });
             });
-            chartLoaded().then(chart => {
-                // TODO: Some charts go blank when resize is triggered. Why is that happening?
-                // TODO: Pass `chart` through to rendering/initialization
+            chartLoaded().then(() => {
                 renderChart();
                 initResizeHandler();
             });

--- a/lib/styles.less
+++ b/lib/styles.less
@@ -5,12 +5,7 @@ body {
 
     background: @style_body_background;
 
-    // Hide the vertical scrollbar that can visible during resizing (depending on browser & OS)
-    // This reduces the 'bouncing' that may occur when resizing the chart
-    // TODO: Figure out how to deal with this in a web components context
     overflow-y: hidden;
-    min-height: 100px;
-    min-width: 100px;
 }
 
 .chart {
@@ -26,12 +21,7 @@ body {
     margin: 0;
     margin: @style_body_margin;
 
-    // Make chart use full container size:
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
+    height: 100%;
 
     &.vis-height-fit {
         overflow: hidden;

--- a/lib/styles.less
+++ b/lib/styles.less
@@ -4,6 +4,11 @@ body {
     padding: 0;
 
     background: @style_body_background;
+
+    // Hide the vertical scrollbar that can visible during resizing (depending on browser & OS)
+    // This reduces the 'bouncing' that may occur when resizing the chart
+    // TODO: Figure out how to deal with this in a web components context
+    overflow-y: hidden;
 }
 
 .chart {

--- a/lib/styles.less
+++ b/lib/styles.less
@@ -9,6 +9,8 @@ body {
     // This reduces the 'bouncing' that may occur when resizing the chart
     // TODO: Figure out how to deal with this in a web components context
     overflow-y: hidden;
+    min-height: 100px;
+    min-width: 100px;
 }
 
 .chart {
@@ -24,7 +26,12 @@ body {
     margin: 0;
     margin: @style_body_margin;
 
-    height: 100%;
+    // Make chart use full container size:
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
 
     &.vis-height-fit {
         overflow: hidden;
@@ -298,9 +305,9 @@ body {
         font-weight: @typography_aboveFooter_fontWeight;
         text-transform: @typography_aboveFooter_textTransform;
         font-size: @typography_aboveFooter_fontSize;
-            & when not (@typography_aboveFooter_lineHeight = __UNDEFINED__) {
-                line-height: @typography_aboveFooter_lineHeight * 1px;
-            }
+        & when not (@typography_aboveFooter_lineHeight = __UNDEFINED__) {
+            line-height: @typography_aboveFooter_lineHeight * 1px;
+        }
         font-style: if(@typography_aboveFooter_cursive = 1, italic, normal);
         text-decoration: if(@typography_aboveFooter_underlined = 1, underline, none);
         color: @typography_aboveFooter_color;
@@ -318,9 +325,9 @@ body {
         font-weight: @typography_notes_fontWeight;
         text-transform: @typography_notes_textTransform;
         font-size: @typography_notes_fontSize;
-            & when not (@typography_notes_lineHeight = __UNDEFINED__) {
-                line-height: @typography_notes_lineHeight * 1px;
-            }
+        & when not (@typography_notes_lineHeight = __UNDEFINED__) {
+            line-height: @typography_notes_lineHeight * 1px;
+        }
         font-style: if(@typography_notes_cursive = 1, italic, normal);
         text-decoration: if(@typography_notes_underlined = 1, underline, none);
         color: @typography_notes_color;
@@ -336,9 +343,9 @@ body {
         font-weight: @typography_belowFooter_fontWeight;
         text-transform: @typography_belowFooter_textTransform;
         font-size: @typography_belowFooter_fontSize;
-            & when not (@typography_belowFooter_lineHeight = __UNDEFINED__) {
-                line-height: @typography_belowFooter_lineHeight * 1px;
-            }
+        & when not (@typography_belowFooter_lineHeight = __UNDEFINED__) {
+            line-height: @typography_belowFooter_lineHeight * 1px;
+        }
         font-style: if(@typography_belowFooter_cursive = 1, italic, normal);
         text-decoration: if(@typography_belowFooter_underlined = 1, underline, none);
         color: @typography_belowFooter_color;
@@ -397,9 +404,9 @@ body {
         font-weight: @typography_footer_fontWeight;
         font-size: @typography_footer_fontSize;
         text-transform: @typography_footer_textTransform;
-            & when not (@typography_footer_lineHeight = __UNDEFINED__) {
-                line-height: @typography_footer_lineHeight * 1px;
-            }
+        & when not (@typography_footer_lineHeight = __UNDEFINED__) {
+            line-height: @typography_footer_lineHeight * 1px;
+        }
         font-style: if(@typography_footer_cursive = 1, italic, normal);
         text-decoration: if(@typography_footer_underlined = 1, underline, none);
         color: @typography_footer_color;
@@ -415,9 +422,9 @@ body {
         border-bottom: @style_footer_links_border_bottom;
         font-family: @typography_links_typeface;
         font-weight: @typography_links_fontWeight;
-            & when not (@typography_links_lineHeight = __UNDEFINED__) {
-                line-height: @typography_links_lineHeight * 1px;
-            }
+        & when not (@typography_links_lineHeight = __UNDEFINED__) {
+            line-height: @typography_links_lineHeight * 1px;
+        }
         font-style: if(@typography_links_cursive = 1, italic, normal);
         text-decoration: if(@typography_links_underlined = 1, underline, nonee);
         color: @typography_links_color;

--- a/lib/styles.less
+++ b/lib/styles.less
@@ -4,8 +4,6 @@ body {
     padding: 0;
 
     background: @style_body_background;
-
-    overflow-y: hidden;
 }
 
 .chart {


### PR DESCRIPTION
### Motivation
- Make chart resizing independent of `window` for future iframe-less embed
- Add generic event bus to `chart` object 

### Changes
- Replace legacy resize handling with `ResizeObserver`-based solution. **Bonus:** Smoother chart resizing (e.g. in editor)
- Add super-simple event handling to chart.js (currently borrowed from Svelte 2, but it would just be a couple of lines to add it directly)
- Trigger 'resize' events from `chart` object for individual visualizations to subscribe
- ~~Expose `getMaxChartHeight` as property of vis for easier access (used together with resize event in d3-maps)~~ I now believe that chart render code should use `vis.size()` instead. 

### TODO
- [x] Test resizing across browsers
- [x] ~~We probably need to polyfill `ResizeObserver` for IE11~~ (falls back to `window.resize` if `ResizeObserver` isn't available) 
