### PR TITLE
Don't crash when applying changes to unknown rows

### DIFF
--- a/lib/dw/dataset/applyChanges.js
+++ b/lib/dw/dataset/applyChanges.js
@@ -19,7 +19,7 @@ export default function applyChanges(chart, dataset) {
                     }
                 }
                 dataset.column(column).title(change.value);
-            } else if (row < numRows) {
+            } else if (row <= numRows) {
                 if (change.previous && change.previous !== 'undefined') {
                     const curValue = dataset.column(column).raw(row - 1);
                     if (curValue !== change.previous) {

--- a/lib/dw/dataset/applyChanges.js
+++ b/lib/dw/dataset/applyChanges.js
@@ -1,39 +1,33 @@
 import _ from 'underscore';
 
-export default function(chart, dataset) {
-    var changes = chart.getMetadata('data.changes', []);
-    var transpose = chart.getMetadata('data.transpose', false);
-    // apply changes
+export default function applyChanges(chart, dataset) {
+    const changes = chart.getMetadata('data.changes', []);
+    const transpose = chart.getMetadata('data.transpose', false);
+    const numRows = dataset.numRows();
     changes.forEach(change => {
-        let row = 'row';
-        let column = 'column';
-        if (transpose) {
-            row = 'column';
-            column = 'row';
-        }
-
-        if (dataset.hasColumn(change[column])) {
+        const row = !transpose ? change.row : change.column;
+        const column = !transpose ? change.column : change.row;
+        if (dataset.hasColumn(column)) {
             change.ignored = false;
-            if (change[row] === 0) {
+            if (row === 0) {
+                // TODO: This should apply only when first row is header.
                 if (change.previous && change.previous !== 'undefined') {
-                    const oldTitle = dataset.column(change[column]).title();
+                    const oldTitle = dataset.column(column).title();
                     if (oldTitle !== change.previous) {
-                        // something is buggy about this, let's revisit later
-                        // change.ignored = true;
+                        // change.ignored = true; // TODO Something is buggy about this, let's revisit later.
                         return;
                     }
                 }
-                dataset.column(change[column]).title(change.value);
-            } else {
+                dataset.column(column).title(change.value);
+            } else if (row < numRows) {
                 if (change.previous && change.previous !== 'undefined') {
-                    const curValue = dataset.column(change[column]).raw(change[row] - 1);
+                    const curValue = dataset.column(column).raw(row - 1);
                     if (curValue !== change.previous) {
-                        // something is buggy about this, let's revisit later
-                        // change.ignored = true;
+                        // change.ignored = true; // TODO Something is buggy about this, let's revisit later.
                         return;
                     }
                 }
-                dataset.column(change[column]).raw(change[row] - 1, change.value);
+                dataset.column(column).raw(row - 1, change.value);
             }
         }
     });

--- a/lib/dw/dataset/applyChanges.js
+++ b/lib/dw/dataset/applyChanges.js
@@ -10,7 +10,6 @@ export default function applyChanges(chart, dataset) {
         if (dataset.hasColumn(column)) {
             change.ignored = false;
             if (row === 0) {
-                // TODO: This should apply only when first row is header.
                 if (change.previous && change.previous !== 'undefined') {
                     const oldTitle = dataset.column(column).title();
                     if (oldTitle !== change.previous) {


### PR DESCRIPTION
### Problem

`applyChanges()` crashes when the `row` of the change is larger than the number of rows in the dataset.

### Solution

Check `row < numRows`.

The rest of the PR is refactoring.