### PR TITLE
Support writing dataset CSV w/o computed columns

### DIFF
--- a/lib/dw/dataset/index.js
+++ b/lib/dw/dataset/index.js
@@ -120,14 +120,17 @@ export default function Dataset(columns) {
 
         /**
          * returns a CSV string representation of the dataset
+         * @param {Object} opt - Options
+         * @param {boolean} [opt.includeComputedColumns=true] - Include computed columns in the CSV.
          * @returns {string}
          */
-        csv() {
+        csv({ includeComputedColumns = true } = {}) {
             let csv = '';
             const sep = ',';
             const quote = '"';
             // add header
             columns.forEach((col, i) => {
+                if (!includeComputedColumns && col.isComputed) return;
                 var t = col.title();
                 if (t.indexOf(quote) > -1) t.replace(quote, '\\' + quote);
                 if (t.indexOf(sep) > -1) t = quote + t + quote;
@@ -137,6 +140,7 @@ export default function Dataset(columns) {
             _.range(dataset.numRows()).forEach(row => {
                 csv += '\n';
                 columns.forEach((col, i) => {
+                    if (!includeComputedColumns && col.isComputed) return;
                     var t = '' + (col.type() === 'date' ? col.raw(row) : col.val(row));
                     if (t.indexOf(quote) > -1) t.replace(quote, '\\' + quote);
                     if (t.indexOf(sep) > -1) t = quote + t + quote;
@@ -151,7 +155,7 @@ export default function Dataset(columns) {
          * @deprecated
          */
         toCSV() {
-            return this.csv();
+            return this.csv(...arguments);
         },
 
         /**

--- a/lib/dw/dataset/index.js
+++ b/lib/dw/dataset/index.js
@@ -120,8 +120,8 @@ export default function Dataset(columns) {
 
         /**
          * returns a CSV string representation of the dataset
-         * @param {Object} opt - Options
-         * @param {boolean} [opt.includeComputedColumns=true] - Include computed columns in the CSV.
+         * @param {Object} opt -- options
+         * @param {boolean} [opt.includeComputedColumns=true] -- include computed columns in the CSV
          * @returns {string}
          */
         csv({ includeComputedColumns = true } = {}) {

--- a/lib/dw/dataset/index.test.js
+++ b/lib/dw/dataset/index.test.js
@@ -1,0 +1,29 @@
+import test from 'ava';
+import Column from './column.js';
+import Dataset from './index.js';
+
+test.beforeEach(t => {
+    const priceEUR = Column('price (EUR)', [24, 0, 80], 'number');
+    priceEUR.isComputed = true;
+    t.context.dataset = Dataset([
+        Column('thing', ['foo', 'bar', 'spam'], 'text'),
+        Column('price', [1.2, undefined, '4'], 'number'),
+        priceEUR
+    ]);
+});
+
+test('Dataset.csv() returns a CSV including computed columns by default', async t => {
+    const expected = `thing,price,price (EUR)
+foo,1.2,24
+bar,undefined,0
+spam,4,80`;
+    t.is(t.context.dataset.csv(), expected);
+});
+
+test('Dataset.csv() returns a CSV without computed columns when an option is passed', async t => {
+    const expected = `thing,price
+foo,1.2
+bar,undefined
+spam,4`;
+    t.is(t.context.dataset.csv({ includeComputedColumns: false }), expected);
+});


### PR DESCRIPTION
#### Motivation

We need this in the new map data upload, because there we use the dataset as the source of truth and sync it with the CSV textarea using `dataset.csv()`. Without this change, computed columns appear in the textarea.

#### Changes

Add an option to `dataset.csv()`.

I'm not sure if such an argument matches the code style of `chart-core`. Let me know if it doesn't and I will change it.
