### PR TITLE
Add deleteRow method

### DIFF
--- a/lib/dw/dataset/column.js
+++ b/lib/dw/dataset/column.js
@@ -227,6 +227,7 @@ export default function Column(name, rows, type) {
 
         deleteRow(i) {
             rows.splice(i, 1);
+            origRows.splice(i, 1);
             column.length = rows.length;
             // invalidate range and total
             range = sum = mean = median = undefined;

--- a/lib/dw/dataset/column.js
+++ b/lib/dw/dataset/column.js
@@ -226,7 +226,6 @@ export default function Column(name, rows, type) {
         },
 
         deleteRow(i) {
-            if (!arguments.length) throw new Error('deleteRow must be called with a row index');
             rows.splice(i, 1);
             column.length = rows.length;
             // invalidate range and total

--- a/lib/dw/dataset/column.js
+++ b/lib/dw/dataset/column.js
@@ -225,6 +225,15 @@ export default function Column(name, rows, type) {
             return column;
         },
 
+        deleteRow(i) {
+            if (!arguments.length) return;
+            rows.splice(i, 1);
+            column.length = rows.length;
+            // invalidate range and total
+            range = sum = mean = median = undefined;
+            return column;
+        },
+
         toString() {
             return name + ' (' + type.name() + ')';
         },

--- a/lib/dw/dataset/column.js
+++ b/lib/dw/dataset/column.js
@@ -226,7 +226,7 @@ export default function Column(name, rows, type) {
         },
 
         deleteRow(i) {
-            if (!arguments.length) return;
+            if (!arguments.length) throw new Error('deleteRow must be called with a row index');
             rows.splice(i, 1);
             column.length = rows.length;
             // invalidate range and total

--- a/lib/dw/dataset/index.js
+++ b/lib/dw/dataset/index.js
@@ -266,6 +266,18 @@ export default function Dataset(columns) {
             for (const column of columns) {
                 column.clear();
             }
+        },
+
+        /**
+         * deletes a row from dataset
+         * @param {number} rowIndex
+         * @returns {dw.Dataset}
+         */
+        deleteRow(rowIndex) {
+            columns.forEach(col => {
+                col.deleteRow(rowIndex);
+            });
+            return dataset;
         }
     };
 

--- a/lib/dw/dataset/index.test.js
+++ b/lib/dw/dataset/index.test.js
@@ -27,3 +27,12 @@ bar,undefined
 spam,4`;
     t.is(t.context.dataset.csv({ includeComputedColumns: false }), expected);
 });
+
+test('Dataset.deleteRow() deletes correct row', async t => {
+    const expected = `thing,price,price (EUR)
+foo,1.2,24
+spam,4,80`;
+    // First row is header, so index of `1` deletes 3rd line in csv.
+    t.context.dataset.deleteRow(1);
+    t.is(t.context.dataset.csv(), expected);
+});


### PR DESCRIPTION
This PR adds `deleteRow` method which allows completely removing a row from a dataset by row index.

This will be used by [the "Delete row" button in new map data step](https://github.com/datawrapper/plugin-simple-maps/pull/36).

There is already a [`filterRows` method in `Column`](https://github.com/datawrapper/chart-core/blob/7c02bdc6f1117c01167d1b1095fd461aba450ec0/lib/dw/dataset/column.js#L213-L226) which is similar. However it does not work for our purposes in map data step, since it relies on `origRows` which is a constant that is set once per instance. But we need to know the current structure of rows when deleting a row.