### PR TITLE
Fix vis registration, set target

### DIFF
--- a/lib/dw/visualization.js
+++ b/lib/dw/visualization.js
@@ -1,5 +1,4 @@
-import { extend } from 'underscore/modules';
-import _clone from 'underscore/modules/clone';
+import { clone } from 'underscore/modules';
 import base from './visualization.base';
 const __vis = {};
 
@@ -22,7 +21,7 @@ function visualization(id, target) {
         return parents.reverse();
     }
 
-    let vis = _clone(base);
+    let vis = clone(base);
 
     let parents = getParents(__vis[id]);
     parents.push({ id, vis: __vis[id] });
@@ -52,7 +51,10 @@ visualization.register = function(id) {
         init = arguments[2];
     }
 
-    extend(vis.prototype, parent, { id: id }, props);
+    __vis[id] = {
+        parentVis,
+        init
+    };
 };
 
 visualization.has = function(id) {

--- a/lib/render.js
+++ b/lib/render.js
@@ -58,6 +58,7 @@ function renderChart() {
     }
 
     vis.size(w, h);
+    vis.target($chart);
 
     // update data link to point to edited dataset
     const csv = chart.dataset().toCSV && chart.dataset().toCSV();

--- a/lib/render.js
+++ b/lib/render.js
@@ -53,12 +53,11 @@ function renderChart() {
         vis = __dw.vis;
     } else {
         // we have to create a new vis
-        vis = __dw.vis = getVis();
+        vis = __dw.vis = getVis($chart);
         chart.vis(vis);
     }
 
     vis.size(w, h);
-    vis.target($chart);
 
     // update data link to point to edited dataset
     const csv = chart.dataset().toCSV && chart.dataset().toCSV();
@@ -157,6 +156,8 @@ async function chartLoaded() {
             .metricPrefix(__dw.params.metricPrefix)
             .theme(dw.theme(__dw.params.themeId));
 
+        chart.locales = __dw.params.locales;
+
         return chart.load(
             __dw.params.data || '',
             __dw.params.preview ? undefined : __dw.params.chartJSON.externalData
@@ -164,8 +165,8 @@ async function chartLoaded() {
     }
 }
 
-function getVis() {
-    const vis = dw.visualization(__dw.params.visId);
+function getVis($chart) {
+    const vis = dw.visualization(__dw.params.visId, $chart);
     vis.meta = __dw.params.visJSON;
     vis.lang = __dw.params.lang;
     return vis;


### PR DESCRIPTION
Fix two things:
- the visualization registration, which I accidentally screwed up during the merge
- actually set the `vis.target` when rendering