### PR TITLE
Save original column name when creating unique name

### DIFF
--- a/lib/dw/dataset/column.js
+++ b/lib/dw/dataset/column.js
@@ -93,7 +93,7 @@ export default function Column(name, rows, type) {
         },
 
         origName() {
-            return origName;
+            return purifyHtml(origName);
         },
 
         // column title (used for presentation)

--- a/lib/dw/dataset/column.js
+++ b/lib/dw/dataset/column.js
@@ -71,6 +71,7 @@ export default function Column(name, rows, type) {
 
     type = type ? columnTypes[type](sample) : guessType(sample);
 
+    let origName = name;
     let range, sum, mean, median;
     const origRows = rows.slice(0);
     let title;
@@ -79,11 +80,20 @@ export default function Column(name, rows, type) {
     var column = {
         // column name (used for reference in chart metadata)
         name() {
-            if (arguments.length) {
+            if (arguments.length >= 1) {
                 name = arguments[0];
+                if (arguments.length === 2) {
+                    origName = arguments[1];
+                } else {
+                    origName = name;
+                }
                 return column;
             }
             return purifyHtml(name);
+        },
+
+        origName() {
+            return origName;
         },
 
         // column title (used for presentation)

--- a/lib/dw/dataset/delimited.js
+++ b/lib/dw/dataset/delimited.js
@@ -172,23 +172,33 @@ class DelimitedParser {
             return t;
         }
 
-        function makeDataset(arrData) {
+        function makeColumns(arrData) {
+            if (!arrData) {
+                return [];
+            }
             arrData = arrData.slice(opts.skipRows);
+            if (!arrData.length) {
+                return [];
+            }
 
             // compute series
+            const firstRow = arrData[0];
             let header = [];
             if (opts.firstRowIsHeader) {
-                header = arrData[0];
+                header = firstRow;
                 arrData.shift();
             }
 
             const columnNames = new Set();
-            const columns = arrData[0].map((_, i) => {
+            return firstRow.map((_, i) => {
                 const name = isString(header[i]) && header[i].replace(/^\s+|\s+$/g, '');
                 const data = arrData.map(row => (row[i] !== '' ? row[i] : opts.emptyValue));
                 return column(name, data);
             });
+        }
 
+        function makeDataset(arrData) {
+            const columns = makeColumns(arrData);
             return dataset(columns);
         }
 

--- a/lib/dw/dataset/delimited.js
+++ b/lib/dw/dataset/delimited.js
@@ -173,7 +173,7 @@ class DelimitedParser {
         }
 
         function makeDataset(arrData) {
-            arrData = arrData.slice(opts.skipRows || 0);
+            arrData = arrData.slice(opts.skipRows);
 
             // compute series
             let header = [];
@@ -184,19 +184,8 @@ class DelimitedParser {
 
             const columnNames = new Set();
             const columns = arrData[0].map((_, i) => {
-                // check that columns names are unique and not empty
-                const origName = isString(header[i]) ? header[i].replace(/^\s+|\s+$/g, '') : '';
-                const baseName = origName !== '' ? origName : 'X.';
-                let name = origName !== '' ? origName : 'X.1';
-                let suffix = 0;
-                while (columnNames.has(name)) {
-                    suffix++;
-                    name = baseName + suffix;
-                }
-                columnNames.add(name);
-
+                const name = isString(header[i]) && header[i].replace(/^\s+|\s+$/g, '');
                 const data = arrData.map(row => (row[i] !== '' ? row[i] : opts.emptyValue));
-
                 return column(name, data);
             });
 

--- a/lib/dw/dataset/delimited.js
+++ b/lib/dw/dataset/delimited.js
@@ -191,7 +191,7 @@ class DelimitedParser {
 
             const columnNames = new Set();
             return firstRow.map((_, i) => {
-                const name = isString(header[i]) && header[i].replace(/^\s+|\s+$/g, '');
+                const name = isString(header[i]) ? header[i].replace(/^\s+|\s+$/g, '') : '';
                 const data = arrData.map(row => (row[i] !== '' ? row[i] : opts.emptyValue));
                 return column(name, data);
             });

--- a/lib/dw/dataset/delimited.js
+++ b/lib/dw/dataset/delimited.js
@@ -173,44 +173,35 @@ class DelimitedParser {
         }
 
         function makeDataset(arrData) {
-            let columns = [];
-            const columnNames = {};
-            const rowCount = arrData.length;
-            const columnCount = arrData[0].length;
-            let rowIndex = opts.skipRows;
+            arrData = arrData.slice(opts.skipRows || 0);
 
             // compute series
-            var srcColumns = [];
+            let header = [];
             if (opts.firstRowIsHeader) {
-                srcColumns = arrData[rowIndex];
-                rowIndex++;
+                header = arrData[0];
+                arrData.shift();
             }
 
-            // check that columns names are unique and not empty
-
-            for (var c = 0; c < columnCount; c++) {
-                let col = isString(srcColumns[c]) ? srcColumns[c].replace(/^\s+|\s+$/g, '') : '';
-                let suffix = col !== '' ? '' : 1;
-                col = col !== '' ? col : 'X.';
-                while (columnNames[col + suffix] !== undefined) {
-                    suffix = suffix === '' ? 1 : suffix + 1;
+            const columnNames = new Set();
+            const columns = arrData[0].map((_, i) => {
+                // check that columns names are unique and not empty
+                const origName = isString(header[i]) ? header[i].replace(/^\s+|\s+$/g, '') : '';
+                const baseName = origName !== '' ? origName : 'X.';
+                let name = origName !== '' ? origName : 'X.1';
+                let suffix = 0;
+                while (columnNames.has(name)) {
+                    suffix++;
+                    name = baseName + suffix;
                 }
-                columns.push({
-                    name: col + suffix,
-                    data: []
-                });
-                columnNames[col + suffix] = true;
-            }
+                columnNames.add(name);
 
-            range(rowIndex, rowCount).forEach(row => {
-                columns.forEach((c, i) => {
-                    c.data.push(arrData[row][i] !== '' ? arrData[row][i] : opts.emptyValue);
-                });
+                const data = arrData.map(row => (row[i] !== '' ? row[i] : opts.emptyValue));
+
+                return column(name, data);
             });
 
-            columns = columns.map(c => column(c.name, c.data));
             return dataset(columns);
-        } // end makeDataset
+        }
 
         arrData = parseCSV(this.__delimiterPatterns, data, opts.delimiter);
         if (opts.transpose) {

--- a/lib/dw/dataset/delimited.test.js
+++ b/lib/dw/dataset/delimited.test.js
@@ -157,7 +157,24 @@ test('load dataset from url', async t => {
     t.is(dataset.numColumns(), 10);
 });
 
-test('skip rows', async t => {
+test('empty csv is parsed as a dataset with one column and no rows', async t => {
+    const csv = `
+`;
+    const dataset = await delimited({ csv }).dataset();
+    t.is(dataset.numColumns(), 1);
+    t.is(dataset.numRows(), 0);
+    t.is(dataset.column(0).name(), 'X.1');
+});
+
+test('csv with only header is parsed as a dataset with several columns and no rows', async t => {
+    const csv = `Party\tWomen\tMen\tTotal
+`;
+    const dataset = await delimited({ csv }).dataset();
+    t.is(dataset.numColumns(), 4);
+    t.is(dataset.numRows(), 0);
+});
+
+test('skipRows processes the csv starting from passed row index', async t => {
     const csv = `Party\tWomen\tMen\tTotal
 CDU/CSU\t45\t192\t237
 SPD\t57\t89\t146
@@ -168,4 +185,16 @@ GRÜNE\t36\t32\t68
     const dataset = await delimited({ csv, skipRows: 2 }).dataset();
     t.deepEqual(dataset.column(0).raw(), ['FDP', 'LINKE', 'GRÜNE']);
     t.deepEqual(dataset.column(1).raw(), ['24', '42', '36']);
+});
+
+test('skipRows larger than the number of csv rows produces an empty dataset', async t => {
+    const csv = `Party\tWomen\tMen\tTotal
+CDU/CSU\t45\t192\t237
+SPD\t57\t89\t146
+FDP\t24\t69\t93
+LINKE\t42\t34\t76
+GRÜNE\t36\t32\t68
+`;
+    const dataset = await delimited({ csv, skipRows: 99 }).dataset();
+    t.is(dataset.numColumns(), 0);
 });

--- a/lib/dw/dataset/delimited.test.js
+++ b/lib/dw/dataset/delimited.test.js
@@ -33,7 +33,7 @@ GRÜNE\t36\t32\t68
     const dataset = await delimited({ csv }).dataset();
     t.deepEqual(
         dataset.columns().map(c => c.name()),
-        ['foo', 'foo1', 'X.1', 'X.2']
+        ['foo', 'foo.1', 'X.1', 'X.2']
     );
 });
 

--- a/lib/dw/dataset/delimited.test.js
+++ b/lib/dw/dataset/delimited.test.js
@@ -22,6 +22,21 @@ GRÜNE\t36\t32\t68
     );
 });
 
+test('simple tsv with empty columns and columns with conflicting names', async t => {
+    const csv = `foo\tfoo\t\t
+CDU/CSU\t45\t192\t237
+SPD\t57\t89\t146
+FDP\t24\t69\t93
+LINKE\t42\t34\t76
+GRÜNE\t36\t32\t68
+`;
+    const dataset = await delimited({ csv }).dataset();
+    t.deepEqual(
+        dataset.columns().map(c => c.name()),
+        ['foo', 'foo1', 'X.1', 'X.2']
+    );
+});
+
 test('nasty tsv with new lines in quoted values', async t => {
     const csv = `Party\t"Women\n\tfoo"\t""Men""\t"Total"
 "CDU/CSU"\t45\t192\t237

--- a/lib/dw/dataset/delimited.test.js
+++ b/lib/dw/dataset/delimited.test.js
@@ -156,3 +156,16 @@ test('load dataset from url', async t => {
     const dataset = await delimited({ url }).dataset();
     t.is(dataset.numColumns(), 10);
 });
+
+test('skip rows', async t => {
+    const csv = `Party\tWomen\tMen\tTotal
+CDU/CSU\t45\t192\t237
+SPD\t57\t89\t146
+FDP\t24\t69\t93
+LINKE\t42\t34\t76
+GRÜNE\t36\t32\t68
+`;
+    const dataset = await delimited({ csv, skipRows: 2 }).dataset();
+    t.deepEqual(dataset.column(0).raw(), ['FDP', 'LINKE', 'GRÜNE']);
+    t.deepEqual(dataset.column(1).raw(), ['24', '42', '36']);
+});

--- a/lib/dw/dataset/delimited.test.js
+++ b/lib/dw/dataset/delimited.test.js
@@ -22,6 +22,31 @@ GRÜNE\t36\t32\t68
     );
 });
 
+test('simple tsv when firstRowIsHeader is false', async t => {
+    const csv = `Party\tWomen\tMen\tTotal
+CDU/CSU\t45\t192\t237
+SPD\t57\t89\t146
+FDP\t24\t69\t93
+LINKE\t42\t34\t76
+GRÜNE\t36\t32\t68
+`;
+    const dataset = await delimited({ csv, firstRowIsHeader: false }).dataset();
+    // column count
+    t.is(dataset.numColumns(), 4);
+    // row count
+    t.is(dataset.numRows(), 6);
+    // column types
+    t.deepEqual(
+        dataset.columns().map(c => c.type()),
+        ['text', 'text', 'text', 'text']
+    );
+    // column names
+    t.deepEqual(
+        dataset.columns().map(c => c.name()),
+        ['X.1', 'X.2', 'X.3', 'X.4']
+    );
+});
+
 test('simple tsv with empty columns and columns with conflicting names', async t => {
     const csv = `foo\tfoo\t\t
 CDU/CSU\t45\t192\t237

--- a/lib/dw/dataset/index.js
+++ b/lib/dw/dataset/index.js
@@ -19,13 +19,22 @@ export default function Dataset(columns) {
     // sets a unique name for a column
     function uniqueName(col) {
         const origColName = col.name();
-        let colName = origColName;
-        let appendix = 1;
-
-        while (columnsByName.hasOwnProperty(colName)) {
-            colName = origColName + '.' + appendix++;
+        let baseColName, suffix, colName;
+        if (origColName) {
+            baseColName = origColName;
+            suffix = 0;
+            colName = baseColName;
+        } else {
+            baseColName = 'X';
+            suffix = 1;
+            colName = `${baseColName}.${suffix}`;
         }
-        if (colName !== origColName) col.name(colName); // rename column
+        while (columnsByName.hasOwnProperty(colName)) {
+            colName = `${baseColName}.${++suffix}`;
+        }
+        if (colName !== origColName) {
+            col.name(colName, origColName);
+        }
     }
 
     // public interface

--- a/lib/dw/dataset/index.test.js
+++ b/lib/dw/dataset/index.test.js
@@ -12,6 +12,54 @@ test.beforeEach(t => {
     ]);
 });
 
+test('Dataset() sets unique names for columns with empty names', async t => {
+    const dataset = Dataset([Column('foo', []), Column('', []), Column('bar', []), Column('', [])]);
+    t.deepEqual(
+        dataset.columns().map(column => [column.name(), column.origName()]),
+        [
+            ['foo', 'foo'],
+            ['X.1', ''],
+            ['bar', 'bar'],
+            ['X.2', '']
+        ]
+    );
+});
+
+test('Dataset() sets unique names for columns with same names', async t => {
+    const dataset = Dataset([
+        Column('foo', []),
+        Column('foo', []),
+        Column('foo.2', []),
+        Column('foo', []),
+        Column('foo.1', []),
+        Column('foo', [])
+    ]);
+    t.deepEqual(
+        dataset.columns().map(column => [column.name(), column.origName()]),
+        [
+            ['foo', 'foo'],
+            ['foo.1', 'foo'],
+            ['foo.2', 'foo.2'],
+            ['foo.3', 'foo'],
+            ['foo.1.1', 'foo.1'],
+            ['foo.4', 'foo']
+        ]
+    );
+});
+
+test('Dataset() handles both columns with empty names and columns with non-unique names', async t => {
+    const dataset = Dataset([Column('', []), Column('X', []), Column('X', []), Column('', [])]);
+    t.deepEqual(
+        dataset.columns().map(column => [column.name(), column.origName()]),
+        [
+            ['X.1', ''],
+            ['X', 'X'],
+            ['X.2', 'X'],
+            ['X.3', '']
+        ]
+    );
+});
+
 test('Dataset.csv() returns a CSV including computed columns by default', async t => {
     const expected = `thing,price,price (EUR)
 foo,1.2,24


### PR DESCRIPTION
#### Motivation

When there is a computed column that has the same name as a normal column (e.g. `price`), it gets renamed with a number suffix (e.g. `price.1`).

This renaming is a good feature, but makes it impossible to later find the column in `metadata.describe.computed-columns`.

#### Changes

- Store the original column name in `Column.origName`.
- Refactor `delimited.makeDataset()`: Move the logic of renaming empty columns (`X.1`, X.2`...) into `Dataset.uniqueName()`.
- Allways rename conflicting columns with the `.1` suffix, instead of just `1`.

   There was an inconsistency: `delimited.makeDataset()` was renaming `price` -> `price1` while `Dataset.uniqueName()` was doing `price` -> `price.1`.

#### Remaining issues

- [ ] Can the fix of the `price1` vs `price.1` inconsistency break existing charts?