### PR TITLE
Add 'is-mobile' class as a substitute for checking max-width via media queries

### DIFF
--- a/lib/Visualization.svelte
+++ b/lib/Visualization.svelte
@@ -258,7 +258,7 @@ Please make sure you called __(key) with a key of type "string".
     let target;
     let isMobile = false;
     const checkBreakpoint = () => {
-        const breakpoint = get(theme, 'data.vis.${chart.type}.mobileBreakpoint', 400);
+        const breakpoint = get(theme, 'data.vis.${chart.type}.mobileBreakpoint', 450);
         isMobile = target.clientWidth <= breakpoint;
     };
 

--- a/lib/Visualization.svelte
+++ b/lib/Visualization.svelte
@@ -255,6 +255,13 @@ Please make sure you called __(key) with a key of type "string".
         return translation;
     }
 
+    let target;
+    let isMobile = false;
+    const checkBreakpoint = () => {
+        const breakpoint = get(theme, 'data.vis.${chart.type}.mobileBreakpoint', 400);
+        isMobile = target.clientWidth <= breakpoint;
+    };
+
     onMount(async () => {
         document.body.classList.toggle('plain', isStylePlain);
         document.body.classList.toggle('static', isStyleStatic);
@@ -283,6 +290,9 @@ Please make sure you called __(key) with a key of type "string".
                 highlightGeom: highlight
             };
         }
+
+        // check mobile breakpoint upon initialization
+        checkBreakpoint();
 
         render(data);
 
@@ -356,6 +366,8 @@ Please make sure you called __(key) with a key of type "string".
     {/if}
 </svelte:head>
 
+<svelte:window on:resize={checkBreakpoint} />
+
 {#if !isStylePlain}
     <BlocksRegion name="dw-chart-header" blocks={regions.header} id="header" />
 
@@ -369,7 +381,13 @@ Please make sure you called __(key) with a key of type "string".
         {@html ariaDescription}
     </div>
 {/if}
-<div id="chart" class="dw-chart-body" aria-hidden={!!ariaDescription} />
+
+<div
+    id="chart"
+    bind:this={target}
+    class:is-mobile={isMobile}
+    aria-hidden={!!ariaDescription}
+    class="dw-chart-body" />
 
 {#if get(theme, 'data.template.afterChart')}
     {@html theme.data.template.afterChart}

--- a/lib/dw/visualization.base.js
+++ b/lib/dw/visualization.base.js
@@ -317,9 +317,6 @@ extend(base, {
         this.clear();
         const el = document.querySelector('#chart');
         el.innerHTML = '';
-        // this removes all event handlers
-        // eslint-disable-next-line
-        el.outerHTML = el.outerHTML;
         remove('.chart .filter-ui');
         remove('.chart .legend');
     },


### PR DESCRIPTION
In web component embeds, we can no longer use @media queries to determine the width of the viewport.

This adds an `.is-mobile` class that we can use to substitute media queries in the individual charts.

This PR replaces #105, which was not supposed to be merged directly into master.