### PR TITLE
Add method for checking if chart is rendering in editor

### DIFF
--- a/lib/dw/chart.js
+++ b/lib/dw/chart.js
@@ -27,6 +27,7 @@ export default function(attributes) {
     const datasetChangeCallbacks = events();
 
     let _translations = {};
+    let _inEditor;
     let _ds;
 
     // public interface
@@ -185,10 +186,13 @@ export default function(attributes) {
             return full ? prepend + val + append : val;
         },
 
-        render(container) {
+        inEditor: () => _inEditor,
+
+        render(container, inEditor) {
             if (!visualization || !theme || !dataset) {
                 throw new Error('cannot render the chart!');
             }
+            _inEditor = inEditor;
             visualization.chart(chart);
             visualization.__init();
             container.parentElement.classList.add('vis-' + visualization.id);

--- a/lib/render.js
+++ b/lib/render.js
@@ -90,7 +90,7 @@ function renderChart() {
 
     // only render if iframe has valid dimensions
     if (getHeightMode() === 'fixed' ? w > 0 : w > 0 && h > 0) {
-        chart.render($chart);
+        chart.render($chart, __dw.params.preview);
     }
 }
 


### PR DESCRIPTION
Quick workaround to already add the `inEditor` method that's used in chart plugins across the 'kill all iframes' project (also included in #106).