### PR TITLE
Add emotion instance to chart.js

### DIFF
--- a/lib/dw/chart.js
+++ b/lib/dw/chart.js
@@ -11,6 +11,7 @@ import { loadScript } from '@datawrapper/shared/fetch';
 import reorderColumns from './dataset/reorderColumns';
 import applyChanges from './dataset/applyChanges';
 import addComputedColumns from './dataset/addComputedColumns';
+import createEmotion from '@emotion/css/create-instance';
 
 let visualization;
 
@@ -192,6 +193,15 @@ export default function(attributes) {
             if (!visualization || !theme || !dataset) {
                 throw new Error('cannot render the chart!');
             }
+
+            // initialize emotion instance
+            if (!this.emotion) {
+                this.emotion = createEmotion({
+                    key: `datawrapper-${visualization.id}`,
+                    container: document.head
+                });
+            }
+
             _inEditor = inEditor;
             visualization.chart(chart);
             visualization.__init();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@datawrapper/chart-core",
-    "version": "8.28.2",
+    "version": "8.29.0-0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@datawrapper/chart-core",
-            "version": "8.28.2",
+            "version": "8.29.0-0",
             "dependencies": {
                 "@datawrapper/expr-eval": "^2.0.2-datawrapper.1",
                 "@datawrapper/polyfills": "2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
                 "@datawrapper/expr-eval": "^2.0.2-datawrapper.1",
                 "@datawrapper/polyfills": "2.1.1",
                 "@datawrapper/shared": "^0.30.4",
+                "@emotion/css": "^11.1.3",
                 "core-js": "3.6.5",
                 "deepmerge": "^4.2.2",
                 "fontfaceobserver": "2.1.0",
@@ -49,7 +50,6 @@
             "version": "7.8.3",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
             "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-            "dev": true,
             "dependencies": {
                 "@babel/highlight": "^7.8.3"
             }
@@ -69,7 +69,6 @@
             "version": "7.9.0",
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
             "integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
-            "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.8.3",
                 "@babel/generator": "^7.9.0",
@@ -96,7 +95,6 @@
             "version": "7.10.0",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.0.tgz",
             "integrity": "sha512-ThoWCJHlgukbtCP79nAK4oLqZt5fVo70AHUni/y8Jotyg5rtJiG2FVl+iJjRNKIyl4hppqztLyAoEWcCvqyOFQ==",
-            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.10.0",
                 "jsesc": "^2.5.1",
@@ -172,7 +170,6 @@
             "version": "7.9.5",
             "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
             "integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
-            "dev": true,
             "dependencies": {
                 "@babel/helper-get-function-arity": "^7.8.3",
                 "@babel/template": "^7.8.3",
@@ -183,7 +180,6 @@
             "version": "7.8.3",
             "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
             "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.8.3"
             }
@@ -201,25 +197,22 @@
             "version": "7.10.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.0.tgz",
             "integrity": "sha512-xKLTpbMkJcvwEsDaTfs9h0IlfUiBLPFfybxaPpPPsQDsZTRg+UKh+86oK7sctHF3OUiRQkb10oS9MXSqgyV6/g==",
-            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.10.0"
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
-            "integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
-            "dev": true,
+            "version": "7.13.12",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
+            "integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
             "dependencies": {
-                "@babel/types": "^7.8.3"
+                "@babel/types": "^7.13.12"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
             "version": "7.9.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
             "integrity": "sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==",
-            "dev": true,
             "dependencies": {
                 "@babel/helper-module-imports": "^7.8.3",
                 "@babel/helper-replace-supers": "^7.8.6",
@@ -234,16 +227,14 @@
             "version": "7.10.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.0.tgz",
             "integrity": "sha512-HgMd8QKA8wMJs5uK/DYKdyzJAEuGt1zyDp9wLMlMR6LitTQTHPUE+msC82ZsEDwq+U3/yHcIXIngRm9MS4IcIg==",
-            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.10.0"
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-            "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-            "dev": true
+            "version": "7.13.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
+            "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ=="
         },
         "node_modules/@babel/helper-regex": {
             "version": "7.8.3",
@@ -271,7 +262,6 @@
             "version": "7.10.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.0.tgz",
             "integrity": "sha512-erl4iVeiANf14JszXP7b69bSrz3e3+qW09pVvEmTWwzRQEOoyb1WFlYCA8d/VjVZGYW8+nGpLh7swf9CifH5wg==",
-            "dev": true,
             "dependencies": {
                 "@babel/helper-member-expression-to-functions": "^7.10.0",
                 "@babel/helper-optimise-call-expression": "^7.10.0",
@@ -283,7 +273,6 @@
             "version": "7.8.3",
             "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
             "integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
-            "dev": true,
             "dependencies": {
                 "@babel/template": "^7.8.3",
                 "@babel/types": "^7.8.3"
@@ -293,16 +282,14 @@
             "version": "7.8.3",
             "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
             "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.8.3"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.9.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
-            "integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==",
-            "dev": true
+            "version": "7.12.11",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+            "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
         },
         "node_modules/@babel/helper-wrap-function": {
             "version": "7.8.3",
@@ -320,7 +307,6 @@
             "version": "7.10.0",
             "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.0.tgz",
             "integrity": "sha512-lQtFJoDZAGf/t2PgR6Z59Q2MwjvOGGsxZ0BAlsrgyDhKuMbe63EfbQmVmcLfyTBj8J4UtiadQimcotvYVg/kVQ==",
-            "dev": true,
             "dependencies": {
                 "@babel/template": "^7.10.0",
                 "@babel/traverse": "^7.10.0",
@@ -331,7 +317,6 @@
             "version": "7.9.0",
             "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
             "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
-            "dev": true,
             "dependencies": {
                 "@babel/helper-validator-identifier": "^7.9.0",
                 "chalk": "^2.0.0",
@@ -342,7 +327,6 @@
             "version": "7.10.0",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.0.tgz",
             "integrity": "sha512-fnDUl1Uy2gThM4IFVW4ISNHqr3cJrCsRkSCasFgx0XDO9JcttDS5ytyBc4Cu4X1+fjoo3IVvFbRD6TeFlHJlEQ==",
-            "dev": true,
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
@@ -470,6 +454,17 @@
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-jsx": {
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.12.13.tgz",
+            "integrity": "sha512-d4HM23Q1K7oq/SLNmG6mRt85l2csmQ0cHRaxRXjKW0YFdEXqlZ5kzFQKH5Uc3rDJECgu+yCRgPkG04Mm98R/1g==",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.12.13"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
             }
         },
         "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
@@ -929,7 +924,6 @@
             "version": "7.9.2",
             "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
             "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
-            "dev": true,
             "dependencies": {
                 "regenerator-runtime": "^0.13.4"
             }
@@ -938,7 +932,6 @@
             "version": "7.10.0",
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.0.tgz",
             "integrity": "sha512-aMLEQn5tcG49LEWrsEwxiRTdaJmvLem3+JMCMSeCy2TILau0IDVyWdm/18ACx7XOCady64FLt6KkHy28tkDQHQ==",
-            "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.8.3",
                 "@babel/parser": "^7.10.0",
@@ -949,7 +942,6 @@
             "version": "7.10.0",
             "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.0.tgz",
             "integrity": "sha512-NZsFleMaLF1zX3NxbtXI/JCs2RPOdpGru6UBdGsfhdsDsP+kFF+h2QQJnMJglxk0kc69YmMFs4A44OJY0tKo5g==",
-            "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.8.3",
                 "@babel/generator": "^7.10.0",
@@ -963,13 +955,11 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.10.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.0.tgz",
-            "integrity": "sha512-t41W8yWFyQFPOAAvPvjyRhejcLGnJTA3iRpFcDbEKwVJ3UnHQePFzLk8GagTsucJlImyNwrGikGsYURrWbQG8w==",
-            "dev": true,
+            "version": "7.13.17",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.17.tgz",
+            "integrity": "sha512-RawydLgxbOPDlTLJNtoIypwdmAy//uQIzlKt2+iBiJaRlVuI6QLUxVAyWGNfOzp8Yu4L4lLIacoCyTNtpb4wiA==",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.9.5",
-                "lodash": "^4.17.13",
+                "@babel/helper-validator-identifier": "^7.12.11",
                 "to-fast-properties": "^2.0.0"
             }
         },
@@ -1018,6 +1008,121 @@
                 "sinon": "^7.3.2",
                 "underscore": "^1.12.0"
             }
+        },
+        "node_modules/@emotion/babel-plugin": {
+            "version": "11.3.0",
+            "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.3.0.tgz",
+            "integrity": "sha512-UZKwBV2rADuhRp+ZOGgNWg2eYgbzKzQXfQPtJbu/PLy8onurxlNCLvxMQEvlr1/GudguPI5IU9qIY1+2z1M5bA==",
+            "dependencies": {
+                "@babel/helper-module-imports": "^7.12.13",
+                "@babel/plugin-syntax-jsx": "^7.12.13",
+                "@babel/runtime": "^7.13.10",
+                "@emotion/hash": "^0.8.0",
+                "@emotion/memoize": "^0.7.5",
+                "@emotion/serialize": "^1.0.2",
+                "babel-plugin-macros": "^2.6.1",
+                "convert-source-map": "^1.5.0",
+                "escape-string-regexp": "^4.0.0",
+                "find-root": "^1.1.0",
+                "source-map": "^0.5.7",
+                "stylis": "^4.0.3"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@emotion/babel-plugin/node_modules/@babel/runtime": {
+            "version": "7.13.17",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.17.tgz",
+            "integrity": "sha512-NCdgJEelPTSh+FEFylhnP1ylq848l1z9t9N0j1Lfbcw0+KXGjsTvUmkxy+voLLXB5SOKMbLLx4jxYliGrYQseA==",
+            "dependencies": {
+                "regenerator-runtime": "^0.13.4"
+            }
+        },
+        "node_modules/@emotion/babel-plugin/node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@emotion/cache": {
+            "version": "11.1.3",
+            "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.1.3.tgz",
+            "integrity": "sha512-n4OWinUPJVaP6fXxWZD9OUeQ0lY7DvtmtSuqtRWT0Ofo/sBLCVSgb4/Oa0Q5eFxcwablRKjUXqXtNZVyEwCAuA==",
+            "dependencies": {
+                "@emotion/memoize": "^0.7.4",
+                "@emotion/sheet": "^1.0.0",
+                "@emotion/utils": "^1.0.0",
+                "@emotion/weak-memoize": "^0.2.5",
+                "stylis": "^4.0.3"
+            }
+        },
+        "node_modules/@emotion/css": {
+            "version": "11.1.3",
+            "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.1.3.tgz",
+            "integrity": "sha512-RSQP59qtCNTf5NWD6xM08xsQdCZmVYnX/panPYvB6LQAPKQB6GL49Njf0EMbS3CyDtrlWsBcmqBtysFvfWT3rA==",
+            "dependencies": {
+                "@emotion/babel-plugin": "^11.0.0",
+                "@emotion/cache": "^11.1.3",
+                "@emotion/serialize": "^1.0.0",
+                "@emotion/sheet": "^1.0.0",
+                "@emotion/utils": "^1.0.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@babel/core": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@emotion/hash": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+            "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+        },
+        "node_modules/@emotion/memoize": {
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.5.tgz",
+            "integrity": "sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ=="
+        },
+        "node_modules/@emotion/serialize": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.2.tgz",
+            "integrity": "sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==",
+            "dependencies": {
+                "@emotion/hash": "^0.8.0",
+                "@emotion/memoize": "^0.7.4",
+                "@emotion/unitless": "^0.7.5",
+                "@emotion/utils": "^1.0.0",
+                "csstype": "^3.0.2"
+            }
+        },
+        "node_modules/@emotion/sheet": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.0.1.tgz",
+            "integrity": "sha512-GbIvVMe4U+Zc+929N1V7nW6YYJtidj31lidSmdYcWozwoBIObXBnaJkKNDjZrLm9Nc0BR+ZyHNaRZxqNZbof5g=="
+        },
+        "node_modules/@emotion/unitless": {
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+            "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+        },
+        "node_modules/@emotion/utils": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
+            "integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
+        },
+        "node_modules/@emotion/weak-memoize": {
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
+            "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.3",
@@ -1225,8 +1330,7 @@
         "node_modules/@types/parse-json": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-            "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
-            "dev": true
+            "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
         },
         "node_modules/@types/resolve": {
             "version": "0.0.8",
@@ -1412,7 +1516,6 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
             "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "dev": true,
             "dependencies": {
                 "color-convert": "^1.9.0"
             },
@@ -1670,6 +1773,16 @@
                 "object.assign": "^4.1.0"
             }
         },
+        "node_modules/babel-plugin-macros": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
+            "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
+            "dependencies": {
+                "@babel/runtime": "^7.7.2",
+                "cosmiconfig": "^6.0.0",
+                "resolve": "^1.12.0"
+            }
+        },
         "node_modules/babel-plugin-transform-async-to-promises": {
             "version": "0.8.15",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-promises/-/babel-plugin-transform-async-to-promises-0.8.15.tgz",
@@ -1905,7 +2018,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
             "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -1941,7 +2053,6 @@
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
             "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-            "dev": true,
             "dependencies": {
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
@@ -2129,7 +2240,6 @@
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
             "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dev": true,
             "dependencies": {
                 "color-name": "1.1.3"
             }
@@ -2137,8 +2247,7 @@
         "node_modules/color-name": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-            "dev": true
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "node_modules/command-line-args": {
             "version": "5.1.1",
@@ -2337,7 +2446,6 @@
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
             "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
-            "dev": true,
             "dependencies": {
                 "safe-buffer": "~5.1.1"
             }
@@ -2379,7 +2487,6 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
             "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
-            "dev": true,
             "dependencies": {
                 "@types/parse-json": "^4.0.0",
                 "import-fresh": "^3.1.0",
@@ -2395,7 +2502,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
             "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
-            "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.0.0",
                 "error-ex": "^1.3.1",
@@ -2443,6 +2549,11 @@
                 "node": ">=8"
             }
         },
+        "node_modules/csstype": {
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
+            "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
+        },
         "node_modules/currently-unhandled": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -2481,7 +2592,6 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
             "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-            "dev": true,
             "dependencies": {
                 "ms": "^2.1.1"
             }
@@ -2765,7 +2875,6 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
             "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-            "dev": true,
             "dependencies": {
                 "is-arrayish": "^0.2.1"
             }
@@ -2783,7 +2892,6 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-            "dev": true,
             "engines": {
                 "node": ">=0.8.0"
             }
@@ -3274,6 +3382,11 @@
                 "node": ">=6"
             }
         },
+        "node_modules/find-root": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+            "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+        },
         "node_modules/find-up": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -3379,7 +3492,6 @@
             "version": "1.0.0-beta.1",
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
             "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
-            "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -3456,7 +3568,6 @@
             "version": "11.12.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
             "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -3704,7 +3815,6 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
             "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
-            "dev": true,
             "dependencies": {
                 "parent-module": "^1.0.0",
                 "resolve-from": "^4.0.0"
@@ -3717,7 +3827,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -3897,8 +4006,7 @@
         "node_modules/is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-            "dev": true
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
         },
         "node_modules/is-binary-path": {
             "version": "2.1.0",
@@ -4161,8 +4269,7 @@
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-            "dev": true
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "node_modules/js-yaml": {
             "version": "3.14.0",
@@ -4355,7 +4462,6 @@
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
             "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-            "dev": true,
             "bin": {
                 "jsesc": "bin/jsesc"
             },
@@ -4372,8 +4478,7 @@
         "node_modules/json-parse-better-errors": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-            "dev": true
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
         },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
@@ -4391,7 +4496,6 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
             "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-            "dev": true,
             "dependencies": {
                 "minimist": "^1.2.5"
             },
@@ -4474,8 +4578,7 @@
         "node_modules/lines-and-columns": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-            "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
-            "dev": true
+            "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
         },
         "node_modules/linkify-it": {
             "version": "2.2.0",
@@ -5062,8 +5165,7 @@
         "node_modules/minimist": {
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-            "dev": true
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
         "node_modules/mkdirp": {
             "version": "0.5.5",
@@ -5086,8 +5188,7 @@
         "node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node_modules/mute-stream": {
             "version": "0.0.8",
@@ -5477,7 +5578,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
             "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-            "dev": true,
             "dependencies": {
                 "callsites": "^3.0.0"
             },
@@ -5536,8 +5636,7 @@
         "node_modules/path-parse": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-            "dev": true
+            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
         },
         "node_modules/path-to-regexp": {
             "version": "1.8.0",
@@ -5551,7 +5650,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
             "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -6045,8 +6143,7 @@
         "node_modules/regenerator-runtime": {
             "version": "0.13.5",
             "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-            "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
-            "dev": true
+            "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
         },
         "node_modules/regenerator-transform": {
             "version": "0.14.4",
@@ -6169,7 +6266,6 @@
             "version": "1.17.0",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
             "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
-            "dev": true,
             "dependencies": {
                 "path-parse": "^1.0.6"
             }
@@ -6296,12 +6392,6 @@
                 "@babel/highlight": "^7.10.4"
             }
         },
-        "node_modules/rollup-plugin-terser/node_modules/@babel/helper-validator-identifier": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-            "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
-            "dev": true
-        },
         "node_modules/rollup-plugin-terser/node_modules/@babel/highlight": {
             "version": "7.10.4",
             "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
@@ -6358,8 +6448,7 @@
         "node_modules/safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
@@ -6371,7 +6460,6 @@
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-            "dev": true,
             "bin": {
                 "semver": "bin/semver"
             }
@@ -6559,7 +6647,6 @@
             "version": "0.5.7",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
             "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -6765,6 +6852,11 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/stylis": {
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.10.tgz",
+            "integrity": "sha512-m3k+dk7QeJw660eIKRRn3xPF6uuvHs/FFzjX3HQ5ove0qYsiygoAhwn5a3IYKaZPo5LrYD0rfVmtv1gNY1uYwg=="
         },
         "node_modules/supertap": {
             "version": "1.0.0",
@@ -7095,7 +7187,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
             "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -7584,7 +7675,6 @@
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
             "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
-            "dev": true,
             "engines": {
                 "node": ">= 6"
             }
@@ -7697,7 +7787,6 @@
             "version": "7.8.3",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
             "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-            "dev": true,
             "requires": {
                 "@babel/highlight": "^7.8.3"
             }
@@ -7717,7 +7806,6 @@
             "version": "7.9.0",
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
             "integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
-            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.8.3",
                 "@babel/generator": "^7.9.0",
@@ -7741,7 +7829,6 @@
             "version": "7.10.0",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.0.tgz",
             "integrity": "sha512-ThoWCJHlgukbtCP79nAK4oLqZt5fVo70AHUni/y8Jotyg5rtJiG2FVl+iJjRNKIyl4hppqztLyAoEWcCvqyOFQ==",
-            "dev": true,
             "requires": {
                 "@babel/types": "^7.10.0",
                 "jsesc": "^2.5.1",
@@ -7817,7 +7904,6 @@
             "version": "7.9.5",
             "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
             "integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
-            "dev": true,
             "requires": {
                 "@babel/helper-get-function-arity": "^7.8.3",
                 "@babel/template": "^7.8.3",
@@ -7828,7 +7914,6 @@
             "version": "7.8.3",
             "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
             "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-            "dev": true,
             "requires": {
                 "@babel/types": "^7.8.3"
             }
@@ -7846,25 +7931,22 @@
             "version": "7.10.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.0.tgz",
             "integrity": "sha512-xKLTpbMkJcvwEsDaTfs9h0IlfUiBLPFfybxaPpPPsQDsZTRg+UKh+86oK7sctHF3OUiRQkb10oS9MXSqgyV6/g==",
-            "dev": true,
             "requires": {
                 "@babel/types": "^7.10.0"
             }
         },
         "@babel/helper-module-imports": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
-            "integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
-            "dev": true,
+            "version": "7.13.12",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
+            "integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
             "requires": {
-                "@babel/types": "^7.8.3"
+                "@babel/types": "^7.13.12"
             }
         },
         "@babel/helper-module-transforms": {
             "version": "7.9.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
             "integrity": "sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==",
-            "dev": true,
             "requires": {
                 "@babel/helper-module-imports": "^7.8.3",
                 "@babel/helper-replace-supers": "^7.8.6",
@@ -7879,16 +7961,14 @@
             "version": "7.10.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.0.tgz",
             "integrity": "sha512-HgMd8QKA8wMJs5uK/DYKdyzJAEuGt1zyDp9wLMlMR6LitTQTHPUE+msC82ZsEDwq+U3/yHcIXIngRm9MS4IcIg==",
-            "dev": true,
             "requires": {
                 "@babel/types": "^7.10.0"
             }
         },
         "@babel/helper-plugin-utils": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-            "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-            "dev": true
+            "version": "7.13.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
+            "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ=="
         },
         "@babel/helper-regex": {
             "version": "7.8.3",
@@ -7916,7 +7996,6 @@
             "version": "7.10.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.0.tgz",
             "integrity": "sha512-erl4iVeiANf14JszXP7b69bSrz3e3+qW09pVvEmTWwzRQEOoyb1WFlYCA8d/VjVZGYW8+nGpLh7swf9CifH5wg==",
-            "dev": true,
             "requires": {
                 "@babel/helper-member-expression-to-functions": "^7.10.0",
                 "@babel/helper-optimise-call-expression": "^7.10.0",
@@ -7928,7 +8007,6 @@
             "version": "7.8.3",
             "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
             "integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
-            "dev": true,
             "requires": {
                 "@babel/template": "^7.8.3",
                 "@babel/types": "^7.8.3"
@@ -7938,16 +8016,14 @@
             "version": "7.8.3",
             "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
             "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-            "dev": true,
             "requires": {
                 "@babel/types": "^7.8.3"
             }
         },
         "@babel/helper-validator-identifier": {
-            "version": "7.9.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
-            "integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==",
-            "dev": true
+            "version": "7.12.11",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+            "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
         },
         "@babel/helper-wrap-function": {
             "version": "7.8.3",
@@ -7965,7 +8041,6 @@
             "version": "7.10.0",
             "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.0.tgz",
             "integrity": "sha512-lQtFJoDZAGf/t2PgR6Z59Q2MwjvOGGsxZ0BAlsrgyDhKuMbe63EfbQmVmcLfyTBj8J4UtiadQimcotvYVg/kVQ==",
-            "dev": true,
             "requires": {
                 "@babel/template": "^7.10.0",
                 "@babel/traverse": "^7.10.0",
@@ -7976,7 +8051,6 @@
             "version": "7.9.0",
             "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
             "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
-            "dev": true,
             "requires": {
                 "@babel/helper-validator-identifier": "^7.9.0",
                 "chalk": "^2.0.0",
@@ -7986,8 +8060,7 @@
         "@babel/parser": {
             "version": "7.10.0",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.0.tgz",
-            "integrity": "sha512-fnDUl1Uy2gThM4IFVW4ISNHqr3cJrCsRkSCasFgx0XDO9JcttDS5ytyBc4Cu4X1+fjoo3IVvFbRD6TeFlHJlEQ==",
-            "dev": true
+            "integrity": "sha512-fnDUl1Uy2gThM4IFVW4ISNHqr3cJrCsRkSCasFgx0XDO9JcttDS5ytyBc4Cu4X1+fjoo3IVvFbRD6TeFlHJlEQ=="
         },
         "@babel/plugin-proposal-async-generator-functions": {
             "version": "7.8.3",
@@ -8106,6 +8179,14 @@
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-jsx": {
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.12.13.tgz",
+            "integrity": "sha512-d4HM23Q1K7oq/SLNmG6mRt85l2csmQ0cHRaxRXjKW0YFdEXqlZ5kzFQKH5Uc3rDJECgu+yCRgPkG04Mm98R/1g==",
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.12.13"
             }
         },
         "@babel/plugin-syntax-nullish-coalescing-operator": {
@@ -8565,7 +8646,6 @@
             "version": "7.9.2",
             "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
             "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
-            "dev": true,
             "requires": {
                 "regenerator-runtime": "^0.13.4"
             }
@@ -8574,7 +8654,6 @@
             "version": "7.10.0",
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.0.tgz",
             "integrity": "sha512-aMLEQn5tcG49LEWrsEwxiRTdaJmvLem3+JMCMSeCy2TILau0IDVyWdm/18ACx7XOCady64FLt6KkHy28tkDQHQ==",
-            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.8.3",
                 "@babel/parser": "^7.10.0",
@@ -8585,7 +8664,6 @@
             "version": "7.10.0",
             "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.0.tgz",
             "integrity": "sha512-NZsFleMaLF1zX3NxbtXI/JCs2RPOdpGru6UBdGsfhdsDsP+kFF+h2QQJnMJglxk0kc69YmMFs4A44OJY0tKo5g==",
-            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.8.3",
                 "@babel/generator": "^7.10.0",
@@ -8599,13 +8677,11 @@
             }
         },
         "@babel/types": {
-            "version": "7.10.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.0.tgz",
-            "integrity": "sha512-t41W8yWFyQFPOAAvPvjyRhejcLGnJTA3iRpFcDbEKwVJ3UnHQePFzLk8GagTsucJlImyNwrGikGsYURrWbQG8w==",
-            "dev": true,
+            "version": "7.13.17",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.17.tgz",
+            "integrity": "sha512-RawydLgxbOPDlTLJNtoIypwdmAy//uQIzlKt2+iBiJaRlVuI6QLUxVAyWGNfOzp8Yu4L4lLIacoCyTNtpb4wiA==",
             "requires": {
-                "@babel/helper-validator-identifier": "^7.9.5",
-                "lodash": "^4.17.13",
+                "@babel/helper-validator-identifier": "^7.12.11",
                 "to-fast-properties": "^2.0.0"
             }
         },
@@ -8650,6 +8726,106 @@
                 "sinon": "^7.3.2",
                 "underscore": "^1.12.0"
             }
+        },
+        "@emotion/babel-plugin": {
+            "version": "11.3.0",
+            "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.3.0.tgz",
+            "integrity": "sha512-UZKwBV2rADuhRp+ZOGgNWg2eYgbzKzQXfQPtJbu/PLy8onurxlNCLvxMQEvlr1/GudguPI5IU9qIY1+2z1M5bA==",
+            "requires": {
+                "@babel/helper-module-imports": "^7.12.13",
+                "@babel/plugin-syntax-jsx": "^7.12.13",
+                "@babel/runtime": "^7.13.10",
+                "@emotion/hash": "^0.8.0",
+                "@emotion/memoize": "^0.7.5",
+                "@emotion/serialize": "^1.0.2",
+                "babel-plugin-macros": "^2.6.1",
+                "convert-source-map": "^1.5.0",
+                "escape-string-regexp": "^4.0.0",
+                "find-root": "^1.1.0",
+                "source-map": "^0.5.7",
+                "stylis": "^4.0.3"
+            },
+            "dependencies": {
+                "@babel/runtime": {
+                    "version": "7.13.17",
+                    "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.17.tgz",
+                    "integrity": "sha512-NCdgJEelPTSh+FEFylhnP1ylq848l1z9t9N0j1Lfbcw0+KXGjsTvUmkxy+voLLXB5SOKMbLLx4jxYliGrYQseA==",
+                    "requires": {
+                        "regenerator-runtime": "^0.13.4"
+                    }
+                },
+                "escape-string-regexp": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+                    "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+                }
+            }
+        },
+        "@emotion/cache": {
+            "version": "11.1.3",
+            "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.1.3.tgz",
+            "integrity": "sha512-n4OWinUPJVaP6fXxWZD9OUeQ0lY7DvtmtSuqtRWT0Ofo/sBLCVSgb4/Oa0Q5eFxcwablRKjUXqXtNZVyEwCAuA==",
+            "requires": {
+                "@emotion/memoize": "^0.7.4",
+                "@emotion/sheet": "^1.0.0",
+                "@emotion/utils": "^1.0.0",
+                "@emotion/weak-memoize": "^0.2.5",
+                "stylis": "^4.0.3"
+            }
+        },
+        "@emotion/css": {
+            "version": "11.1.3",
+            "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.1.3.tgz",
+            "integrity": "sha512-RSQP59qtCNTf5NWD6xM08xsQdCZmVYnX/panPYvB6LQAPKQB6GL49Njf0EMbS3CyDtrlWsBcmqBtysFvfWT3rA==",
+            "requires": {
+                "@emotion/babel-plugin": "^11.0.0",
+                "@emotion/cache": "^11.1.3",
+                "@emotion/serialize": "^1.0.0",
+                "@emotion/sheet": "^1.0.0",
+                "@emotion/utils": "^1.0.0"
+            }
+        },
+        "@emotion/hash": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+            "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+        },
+        "@emotion/memoize": {
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.5.tgz",
+            "integrity": "sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ=="
+        },
+        "@emotion/serialize": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.2.tgz",
+            "integrity": "sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==",
+            "requires": {
+                "@emotion/hash": "^0.8.0",
+                "@emotion/memoize": "^0.7.4",
+                "@emotion/unitless": "^0.7.5",
+                "@emotion/utils": "^1.0.0",
+                "csstype": "^3.0.2"
+            }
+        },
+        "@emotion/sheet": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.0.1.tgz",
+            "integrity": "sha512-GbIvVMe4U+Zc+929N1V7nW6YYJtidj31lidSmdYcWozwoBIObXBnaJkKNDjZrLm9Nc0BR+ZyHNaRZxqNZbof5g=="
+        },
+        "@emotion/unitless": {
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+            "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+        },
+        "@emotion/utils": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
+            "integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
+        },
+        "@emotion/weak-memoize": {
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
+            "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
         },
         "@nodelib/fs.scandir": {
             "version": "2.1.3",
@@ -8830,8 +9006,7 @@
         "@types/parse-json": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-            "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
-            "dev": true
+            "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
         },
         "@types/resolve": {
             "version": "0.0.8",
@@ -8981,7 +9156,6 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
             "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "dev": true,
             "requires": {
                 "color-convert": "^1.9.0"
             }
@@ -9190,6 +9364,16 @@
                 "object.assign": "^4.1.0"
             }
         },
+        "babel-plugin-macros": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
+            "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
+            "requires": {
+                "@babel/runtime": "^7.7.2",
+                "cosmiconfig": "^6.0.0",
+                "resolve": "^1.12.0"
+            }
+        },
         "babel-plugin-transform-async-to-promises": {
             "version": "0.8.15",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-promises/-/babel-plugin-transform-async-to-promises-0.8.15.tgz",
@@ -9383,8 +9567,7 @@
         "callsites": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-            "dev": true
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
         },
         "camelcase": {
             "version": "5.3.1",
@@ -9411,7 +9594,6 @@
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
             "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-            "dev": true,
             "requires": {
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
@@ -9564,7 +9746,6 @@
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
             "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dev": true,
             "requires": {
                 "color-name": "1.1.3"
             }
@@ -9572,8 +9753,7 @@
         "color-name": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-            "dev": true
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "command-line-args": {
             "version": "5.1.1",
@@ -9743,7 +9923,6 @@
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
             "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
-            "dev": true,
             "requires": {
                 "safe-buffer": "~5.1.1"
             }
@@ -9781,7 +9960,6 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
             "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
-            "dev": true,
             "requires": {
                 "@types/parse-json": "^4.0.0",
                 "import-fresh": "^3.1.0",
@@ -9794,7 +9972,6 @@
                     "version": "5.0.0",
                     "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
                     "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
-                    "dev": true,
                     "requires": {
                         "@babel/code-frame": "^7.0.0",
                         "error-ex": "^1.3.1",
@@ -9828,6 +10005,11 @@
             "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
             "dev": true
         },
+        "csstype": {
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
+            "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
+        },
         "currently-unhandled": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -9860,7 +10042,6 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
             "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-            "dev": true,
             "requires": {
                 "ms": "^2.1.1"
             }
@@ -10094,7 +10275,6 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
             "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-            "dev": true,
             "requires": {
                 "is-arrayish": "^0.2.1"
             }
@@ -10108,8 +10288,7 @@
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-            "dev": true
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "eslint": {
             "version": "6.8.0",
@@ -10495,6 +10674,11 @@
                 }
             }
         },
+        "find-root": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+            "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+        },
         "find-up": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -10580,8 +10764,7 @@
         "gensync": {
             "version": "1.0.0-beta.1",
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
-            "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
-            "dev": true
+            "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg=="
         },
         "get-caller-file": {
             "version": "2.0.5",
@@ -10639,8 +10822,7 @@
         "globals": {
             "version": "11.12.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-            "dev": true
+            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
         },
         "globby": {
             "version": "11.0.0",
@@ -10832,7 +11014,6 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
             "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
-            "dev": true,
             "requires": {
                 "parent-module": "^1.0.0",
                 "resolve-from": "^4.0.0"
@@ -10841,8 +11022,7 @@
                 "resolve-from": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-                    "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-                    "dev": true
+                    "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
                 }
             }
         },
@@ -10987,8 +11167,7 @@
         "is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-            "dev": true
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
         },
         "is-binary-path": {
             "version": "2.1.0",
@@ -11193,8 +11372,7 @@
         "js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-            "dev": true
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "js-yaml": {
             "version": "3.14.0",
@@ -11347,8 +11525,7 @@
         "jsesc": {
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-            "dev": true
+            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
         },
         "json-buffer": {
             "version": "3.0.0",
@@ -11359,8 +11536,7 @@
         "json-parse-better-errors": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-            "dev": true
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
         },
         "json-schema-traverse": {
             "version": "0.4.1",
@@ -11378,7 +11554,6 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
             "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-            "dev": true,
             "requires": {
                 "minimist": "^1.2.5"
             }
@@ -11443,8 +11618,7 @@
         "lines-and-columns": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-            "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
-            "dev": true
+            "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
         },
         "linkify-it": {
             "version": "2.2.0",
@@ -11929,8 +12103,7 @@
         "minimist": {
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-            "dev": true
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
         "mkdirp": {
             "version": "0.5.5",
@@ -11950,8 +12123,7 @@
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "mute-stream": {
             "version": "0.0.8",
@@ -12269,7 +12441,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
             "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-            "dev": true,
             "requires": {
                 "callsites": "^3.0.0"
             }
@@ -12310,8 +12481,7 @@
         "path-parse": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-            "dev": true
+            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
         },
         "path-to-regexp": {
             "version": "1.8.0",
@@ -12324,8 +12494,7 @@
         "path-type": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-            "dev": true
+            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
         },
         "picomatch": {
             "version": "2.2.2",
@@ -12706,8 +12875,7 @@
         "regenerator-runtime": {
             "version": "0.13.5",
             "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-            "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
-            "dev": true
+            "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
         },
         "regenerator-transform": {
             "version": "0.14.4",
@@ -12811,7 +12979,6 @@
             "version": "1.17.0",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
             "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
-            "dev": true,
             "requires": {
                 "path-parse": "^1.0.6"
             }
@@ -12916,12 +13083,6 @@
                         "@babel/highlight": "^7.10.4"
                     }
                 },
-                "@babel/helper-validator-identifier": {
-                    "version": "7.10.4",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-                    "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
-                    "dev": true
-                },
                 "@babel/highlight": {
                     "version": "7.10.4",
                     "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
@@ -12976,8 +13137,7 @@
         "safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "safer-buffer": {
             "version": "2.1.2",
@@ -12988,8 +13148,7 @@
         "semver": {
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-            "dev": true
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         },
         "semver-compare": {
             "version": "1.0.0",
@@ -13143,8 +13302,7 @@
         "source-map": {
             "version": "0.5.7",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-            "dev": true
+            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "source-map-support": {
             "version": "0.5.19",
@@ -13313,6 +13471,11 @@
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
             "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
             "dev": true
+        },
+        "stylis": {
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.10.tgz",
+            "integrity": "sha512-m3k+dk7QeJw660eIKRRn3xPF6uuvHs/FFzjX3HQ5ove0qYsiygoAhwn5a3IYKaZPo5LrYD0rfVmtv1gNY1uYwg=="
         },
         "supertap": {
             "version": "1.0.0",
@@ -13573,8 +13736,7 @@
         "to-fast-properties": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-            "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-            "dev": true
+            "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
         },
         "to-readable-stream": {
             "version": "1.0.0",
@@ -13964,8 +14126,7 @@
         "yaml": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
-            "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
-            "dev": true
+            "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
         },
         "yargs": {
             "version": "15.3.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "@datawrapper/expr-eval": "^2.0.2-datawrapper.1",
         "@datawrapper/polyfills": "2.1.1",
         "@datawrapper/shared": "^0.30.4",
+        "@emotion/css": "^11.1.3",
         "core-js": "3.6.5",
         "deepmerge": "^4.2.2",
         "fontfaceobserver": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@datawrapper/chart-core",
-    "version": "8.28.2",
+    "version": "8.29.0-0",
     "description": "Svelte component to render charts. Used by Sapper App and Node API.",
     "main": "index.js",
     "files": [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -31,6 +31,10 @@ module.exports = [
         input: path.resolve(__dirname, 'main.js'),
         plugins: [
             svelte({ hydratable: true }),
+            // for @emotion/css
+            replace({
+                'process.env.NODE_ENV': JSON.stringify('production')
+            }),
             resolve(),
             commonjs(),
             production &&
@@ -53,6 +57,10 @@ module.exports = [
         input: path.resolve(__dirname, 'lib/Visualization.svelte'),
         plugins: [
             svelte({ generate: 'ssr', hydratable: true }),
+            // for @emotion/css
+            replace({
+                'process.env.NODE_ENV': JSON.stringify('production')
+            }),
             resolve(),
             commonjs(),
             babel({

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -33,10 +33,6 @@ module.exports = [
             svelte({ hydratable: true }),
             resolve(),
             commonjs(),
-            // for @emotion/css
-            replace({
-                'process.env.NODE_ENV': JSON.stringify('production')
-            }),
             production &&
                 babel({
                     ...babelConfig,
@@ -59,10 +55,6 @@ module.exports = [
             svelte({ generate: 'ssr', hydratable: true }),
             resolve(),
             commonjs(),
-            // for @emotion/css
-            replace({
-                'process.env.NODE_ENV': JSON.stringify('production')
-            }),
             babel({
                 ...babelConfig,
                 presets: [['@babel/env', { targets: { node: true } }]]

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -31,12 +31,12 @@ module.exports = [
         input: path.resolve(__dirname, 'main.js'),
         plugins: [
             svelte({ hydratable: true }),
+            resolve(),
+            commonjs(),
             // for @emotion/css
             replace({
                 'process.env.NODE_ENV': JSON.stringify('production')
             }),
-            resolve(),
-            commonjs(),
             production &&
                 babel({
                     ...babelConfig,
@@ -57,12 +57,12 @@ module.exports = [
         input: path.resolve(__dirname, 'lib/Visualization.svelte'),
         plugins: [
             svelte({ generate: 'ssr', hydratable: true }),
+            resolve(),
+            commonjs(),
             // for @emotion/css
             replace({
                 'process.env.NODE_ENV': JSON.stringify('production')
             }),
-            resolve(),
-            commonjs(),
             babel({
                 ...babelConfig,
                 presets: [['@babel/env', { targets: { node: true } }]]
@@ -118,7 +118,8 @@ module.exports = [
             resolve(),
             commonjs(),
             replace({
-                __chartCoreVersion__: require('./package.json').version
+                __chartCoreVersion__: require('./package.json').version,
+                'process.env.NODE_ENV': JSON.stringify('production')
             }),
             babel({
                 ...babelConfig,


### PR DESCRIPTION
This provides the `emotion/css` instance that the chart plugins in the 'kill all iframes' project rely on. 