### PR TITLE
Support writing CSV without header and fix quoting

### DIFF
--- a/lib/dw/dataset/index.mjs
+++ b/lib/dw/dataset/index.mjs
@@ -137,7 +137,7 @@ export default function Dataset(columns) {
          * @returns {object[]}
          */
         list() {
-            return range(columns[0].length).map(function (r) {
+            return range(columns[0].length).map(function(r) {
                 var o = {};
                 columns.forEach(col => {
                     o[col.name()] = col.val(r);
@@ -257,12 +257,12 @@ export default function Dataset(columns) {
         columnOrder(sortOrder) {
             if (arguments.length) {
                 columns.length = 0;
-                sortOrder.forEach(function (i) {
+                sortOrder.forEach(function(i) {
                     columns.push(origColumns[i]);
                 });
                 return dataset;
             }
-            return columns.map(function (c) {
+            return columns.map(function(c) {
                 return origColumns.indexOf(c);
             });
         },

--- a/lib/dw/dataset/index.mjs
+++ b/lib/dw/dataset/index.mjs
@@ -38,7 +38,7 @@ export default function Dataset(columns) {
     }
 
     function escapeCSVValue(value, delimiter, quoteChar) {
-        let s = String(value);
+        const s = String(value);
         if (s.indexOf(quoteChar) !== -1) {
             return (
                 quoteChar + s.replace(new RegExp(quoteChar, 'g'), quoteChar + quoteChar) + quoteChar

--- a/lib/dw/dataset/index.mjs
+++ b/lib/dw/dataset/index.mjs
@@ -40,11 +40,17 @@ export default function Dataset(columns) {
     function escapeCSVValue(value, delimiter, quoteChar) {
         const s = String(value);
         if (s.indexOf(quoteChar) !== -1) {
+            // A double-quote appearing inside a field MUST be escaped by preceding it with another
+            // double quote, and the field itself MUST be enclosed in double quotes.
+            // See paragraph 8 at https://csv-spec.org/#csv-format-specification
             return (
                 quoteChar + s.replace(new RegExp(quoteChar, 'g'), quoteChar + quoteChar) + quoteChar
             );
         }
         if (s.indexOf(delimiter) !== -1) {
+            // Fields containing line breaks (CRLF, LF, or CR), double quotes, or the delimiter
+            // character (normally a comma) MUST be enclosed in double-quotes.
+            // See paragraph 7 at https://csv-spec.org/#csv-format-specification
             return quoteChar + s + quoteChar;
         }
         return s;
@@ -131,7 +137,7 @@ export default function Dataset(columns) {
          * @returns {object[]}
          */
         list() {
-            return range(columns[0].length).map(function(r) {
+            return range(columns[0].length).map(function (r) {
                 var o = {};
                 columns.forEach(col => {
                     o[col.name()] = col.val(r);
@@ -251,12 +257,12 @@ export default function Dataset(columns) {
         columnOrder(sortOrder) {
             if (arguments.length) {
                 columns.length = 0;
-                sortOrder.forEach(function(i) {
+                sortOrder.forEach(function (i) {
                     columns.push(origColumns[i]);
                 });
                 return dataset;
             }
-            return columns.map(function(c) {
+            return columns.map(function (c) {
                 return origColumns.indexOf(c);
             });
         },

--- a/lib/dw/dataset/index.mjs
+++ b/lib/dw/dataset/index.mjs
@@ -37,6 +37,19 @@ export default function Dataset(columns) {
         }
     }
 
+    function escapeCSVValue(value, delimiter, quoteChar) {
+        let s = String(value);
+        if (s.indexOf(quoteChar) !== -1) {
+            return (
+                quoteChar + s.replace(new RegExp(quoteChar, 'g'), quoteChar + quoteChar) + quoteChar
+            );
+        }
+        if (s.indexOf(delimiter) !== -1) {
+            return quoteChar + s + quoteChar;
+        }
+        return s;
+    }
+
     // public interface
     const dataset = {
         /**
@@ -131,32 +144,36 @@ export default function Dataset(columns) {
          * returns a CSV string representation of the dataset
          * @param {Object} opt -- options
          * @param {boolean} [opt.includeComputedColumns=true] -- include computed columns in the CSV
+         * @param {boolean} [opt.includeHeader=true] -- include header row in the CSV
          * @returns {string}
          */
-        csv({ includeComputedColumns = true } = {}) {
-            let csv = '';
-            const sep = ',';
-            const quote = '"';
-            // add header
-            columns.forEach((col, i) => {
-                if (!includeComputedColumns && col.isComputed) return;
-                var t = col.title();
-                if (t.indexOf(quote) > -1) t.replace(quote, '\\' + quote);
-                if (t.indexOf(sep) > -1) t = quote + t + quote;
-                csv += (i > 0 ? sep : '') + t;
-            });
-            // add values
-            range(dataset.numRows()).forEach(row => {
-                csv += '\n';
-                columns.forEach((col, i) => {
-                    if (!includeComputedColumns && col.isComputed) return;
-                    var t = '' + (col.type() === 'date' ? col.raw(row) : col.val(row));
-                    if (t.indexOf(quote) > -1) t.replace(quote, '\\' + quote);
-                    if (t.indexOf(sep) > -1) t = quote + t + quote;
-                    csv += (i > 0 ? sep : '') + t;
-                });
-            });
-            return csv;
+        csv({
+            includeComputedColumns = true,
+            includeHeader = true,
+            delimiter = ',',
+            quoteChar = '"',
+            lineTerminator = '\n'
+        } = {}) {
+            const numRows = dataset.numRows();
+            const rows = [];
+            const filteredColumns = includeComputedColumns
+                ? columns
+                : columns.filter(col => !col.isComputed);
+            if (includeHeader) {
+                rows.push(filteredColumns.map(col => col.title()));
+            }
+            for (var row = 0; row < numRows; row++) {
+                rows.push(
+                    filteredColumns.map(col =>
+                        col.type() === 'date' ? col.raw(row) : col.val(row)
+                    )
+                );
+            }
+            return rows
+                .map(row =>
+                    row.map(value => escapeCSVValue(value, delimiter, quoteChar)).join(delimiter)
+                )
+                .join(lineTerminator);
         },
 
         /**

--- a/lib/dw/dataset/index.mjs
+++ b/lib/dw/dataset/index.mjs
@@ -47,7 +47,7 @@ export default function Dataset(columns) {
                 quoteChar + s.replace(new RegExp(quoteChar, 'g'), quoteChar + quoteChar) + quoteChar
             );
         }
-        if (s.indexOf(delimiter) !== -1) {
+        if (new RegExp(`[\n\r${delimiter}]`).test(s)) {
             // Fields containing line breaks (CRLF, LF, or CR), double quotes, or the delimiter
             // character (normally a comma) MUST be enclosed in double-quotes.
             // See paragraph 7 at https://csv-spec.org/#csv-format-specification

--- a/lib/dw/dataset/index.test.mjs
+++ b/lib/dw/dataset/index.test.mjs
@@ -61,7 +61,7 @@ test('Dataset() handles both columns with empty names and columns with non-uniqu
     );
 });
 
-test('Dataset.csv() returns a CSV including computed columns by default', async t => {
+test('Dataset.csv() returns a CSV including computed columns and the header by default', async t => {
     const expected = `thing,price,price (EUR)
 foo,1.2,24
 bar,undefined,0
@@ -75,6 +75,13 @@ foo,1.2
 bar,undefined
 spam,4`;
     t.is(t.context.dataset.csv({ includeComputedColumns: false }), expected);
+});
+
+test('Dataset.csv() returns a CSV without the header row when an option is passed', async t => {
+    const expected = `foo,1.2,24
+bar,undefined,0
+spam,4,80`;
+    t.is(t.context.dataset.csv({ includeHeader: false }), expected);
 });
 
 test('Dataset.csv() quoting', async t => {

--- a/lib/dw/dataset/index.test.mjs
+++ b/lib/dw/dataset/index.test.mjs
@@ -88,6 +88,8 @@ test('Dataset.csv() quoting', async t => {
     const sourceValues = [
         'standard',
         '"quoted"',
+        'line\nfeed',
+        'carriage\rreturn',
         'with,delimiter',
         '"with,delimiter-quoted"',
         'with"quote',
@@ -96,6 +98,8 @@ test('Dataset.csv() quoting', async t => {
     const expectedCSV = `X.1
 standard
 """quoted"""
+"line\nfeed"
+"carriage\rreturn"
 "with,delimiter"
 """with,delimiter-quoted"""
 "with""quote"

--- a/lib/dw/dataset/index.test.mjs
+++ b/lib/dw/dataset/index.test.mjs
@@ -1,6 +1,7 @@
 import test from 'ava';
 import Column from './column.mjs';
 import Dataset from './index.mjs';
+import delimited from './delimited.mjs';
 
 test.beforeEach(t => {
     const priceEUR = Column('price (EUR)', [24, 0, 80], 'number');
@@ -74,6 +75,31 @@ foo,1.2
 bar,undefined
 spam,4`;
     t.is(t.context.dataset.csv({ includeComputedColumns: false }), expected);
+});
+
+test('Dataset.csv() quoting', async t => {
+    const sourceValues = [
+        'standard',
+        '"quoted"',
+        'with,delimiter',
+        '"with,delimiter-quoted"',
+        'with"quote',
+        '"with"quote-quoted"'
+    ];
+    const expectedCSV = `X.1
+standard
+"""quoted"""
+"with,delimiter"
+"""with,delimiter-quoted"""
+"with""quote"
+"""with""quote-quoted"""`;
+
+    const sourceDataset = Dataset([Column('X.1', sourceValues, 'text')]);
+    const resultCSV = sourceDataset.csv();
+    t.is(resultCSV, expectedCSV);
+
+    const parsedDataset = await delimited({ csv: resultCSV }).dataset();
+    t.deepEqual(parsedDataset.column(0).raw(), sourceValues);
 });
 
 test('Dataset.deleteRow() deletes correct row', async t => {


### PR DESCRIPTION
#### Motivation

In the new map data upload, we need to be able to create a CSV from a dataset without the header.

#### Changes

1. Add option `includeHeader` to `dataset.csv()`.

2. Fix the format of the created CSV to match the CSV specification.

    When there is `"` in a value, it should be quoted as `""` (not as `\"`, which the code used to do).

    See that the unit tests creates a CSV and then parses it again and it matches.