### PR TITLE
Backwards-compatible column name generation

### DIFF
--- a/lib/dw/dataset/delimited.js
+++ b/lib/dw/dataset/delimited.js
@@ -183,17 +183,28 @@ class DelimitedParser {
 
             // compute series
             const firstRow = arrData[0];
+            const columnNames = {};
             let header = [];
+            let srcColumns = [];
+            let rowIndex = 0;
             if (opts.firstRowIsHeader) {
                 header = firstRow;
+                srcColumns = arrData[rowIndex];
+                rowIndex++;
                 arrData.shift();
             }
 
-            const columnNames = new Set();
             return firstRow.map((_, i) => {
                 const name = isString(header[i]) ? header[i].replace(/^\s+|\s+$/g, '') : '';
                 const data = arrData.map(row => (row[i] !== '' ? row[i] : opts.emptyValue));
-                return column(name, data);
+                let col = isString(srcColumns[i]) ? srcColumns[i].replace(/^\s+|\s+$/g, '') : '';
+                let suffix = col !== '' ? '' : 1;
+                col = col !== '' ? col : 'X.';
+                while (columnNames[col + suffix] !== undefined) {
+                    suffix = suffix === '' ? 1 : suffix + 1;
+                }
+                columnNames[col + suffix] = true;
+                return column(col + suffix, data);
             });
         }
 

--- a/lib/dw/dataset/delimited.test.js
+++ b/lib/dw/dataset/delimited.test.js
@@ -58,7 +58,7 @@ GRÜNE\t36\t32\t68
     const dataset = await delimited({ csv }).dataset();
     t.deepEqual(
         dataset.columns().map(c => c.name()),
-        ['foo', 'foo.1', 'X.1', 'X.2']
+        ['foo', 'foo1', 'X.1', 'X.2']
     );
 });
 


### PR DESCRIPTION
The changes introduced in [this PR](https://github.com/datawrapper/chart-core/pull/104#issue-614414453) made our column name generation more consistent, but in a non-backwards compatible manner. This proved problematic, so I'm reverting back to the old logic.

Making it consistent is still a good idea, but it needs to be coupled with a metadata migration to copy over the values stored in the `column-format` in the `metadata` objects.