### PR TITLE
inEditor should only be true in step 3

### DIFF
--- a/lib/dw/chart.js
+++ b/lib/dw/chart.js
@@ -28,7 +28,6 @@ export default function(attributes) {
     const datasetChangeCallbacks = events();
 
     let _translations = {};
-    let _inEditor;
     let _ds;
 
     // public interface
@@ -187,9 +186,20 @@ export default function(attributes) {
             return full ? prepend + val + append : val;
         },
 
-        inEditor: () => _inEditor,
+        inEditor: () => {
+            try {
+                return (
+                    window.parent !== window &&
+                    window.parent.dw &&
+                    window.parent.dw.backend &&
+                    window.parent.dw.backend.hooks
+                );
+            } catch (ex) {
+                return false;
+            }
+        },
 
-        render(container, inEditor) {
+        render(container) {
             if (!visualization || !theme || !dataset) {
                 throw new Error('cannot render the chart!');
             }
@@ -202,7 +212,6 @@ export default function(attributes) {
                 });
             }
 
-            _inEditor = inEditor;
             visualization.chart(chart);
             visualization.__init();
             container.parentElement.classList.add('vis-' + visualization.id);

--- a/lib/render.js
+++ b/lib/render.js
@@ -90,7 +90,7 @@ function renderChart() {
 
     // only render if iframe has valid dimensions
     if (getHeightMode() === 'fixed' ? w > 0 : w > 0 && h > 0) {
-        chart.render($chart, __dw.params.preview);
+        chart.render($chart);
     }
 }
 


### PR DESCRIPTION
`inEditor` should only be true when the visualization is embedded in the editor, not whenever the `preview` endpoint is used. This is because there are various scenarios where we open the `preview` endpoint but don't provide the surrounding editor controls, such as when a visualization is viewed in the preview modal on the 'My Charts' page, in the publish step of the editor or internally during exporting.