### PR TITLE
Add Edit in Datawrapper link to footer

### DIFF
--- a/lib/Visualization.svelte
+++ b/lib/Visualization.svelte
@@ -203,6 +203,7 @@
             block.props = {
                 ...(block.data || {}),
                 ...blockProps,
+                config: { frontendDomain },
                 id: block.id
             };
             if (block.component.test) {
@@ -219,23 +220,20 @@
 
     let regions;
     $: {
-        const config = { frontendDomain };
         // build all the region
         regions = {
-            header: getBlocks(allBlocks, 'header', { chart, data, theme, isStyleStatic, config }),
+            header: getBlocks(allBlocks, 'header', { chart, data, theme, isStyleStatic }),
             aboveFooter: getBlocks(allBlocks, 'aboveFooter', {
                 chart,
                 data,
                 theme,
-                isStyleStatic,
-                config
+                isStyleStatic
             }),
             footerLeft: getBlocks(allBlocks, 'footerLeft', {
                 chart,
                 data,
                 theme,
-                isStyleStatic,
-                config
+                isStyleStatic
             }),
             footerCenter: getBlocks(allBlocks, 'footerCenter', {
                 chart,
@@ -247,24 +245,21 @@
                 chart,
                 data,
                 theme,
-                isStyleStatic,
-                config
+                isStyleStatic
             }),
             belowFooter: getBlocks(allBlocks, 'belowFooter', {
                 chart,
                 data,
                 theme,
-                isStyleStatic,
-                config
+                isStyleStatic
             }),
             afterBody: getBlocks(allBlocks, 'afterBody', {
                 chart,
                 data,
                 theme,
-                isStyleStatic,
-                config
+                isStyleStatic
             }),
-            menu: getBlocks(allBlocks, 'menu', { chart, data, theme, isStyleStatic, config })
+            menu: getBlocks(allBlocks, 'menu', { chart, data, theme, isStyleStatic })
         };
     }
 

--- a/lib/Visualization.svelte
+++ b/lib/Visualization.svelte
@@ -8,6 +8,7 @@
     import Byline from './blocks/Byline.svelte';
     import Notes from './blocks/Notes.svelte';
     import GetTheData from './blocks/GetTheData.svelte';
+    import EditInDatawrapper from './blocks/EditInDatawrapper.svelte';
     import Embed from './blocks/Embed.svelte';
     import Logo from './blocks/Logo.svelte';
     import Rectangle from './blocks/Rectangle.svelte';
@@ -99,6 +100,16 @@
                 chart.type !== 'locator-map',
             priority: 30,
             component: GetTheData
+        },
+        {
+            id: 'edit-in-datawrapper',
+            region: 'footerLeft',
+            test: ({ chart, isStyleStatic }) =>
+                get(theme, 'data.options.footer.getTheData.enabled') &&
+                get(chart, 'metadata.publish.edit-in-datawrapper', false) &&
+                !isStyleStatic,
+            priority: 31,
+            component: EditInDatawrapper
         },
         {
             id: 'embed',
@@ -208,21 +219,52 @@
 
     let regions;
     $: {
+        const config = { frontendDomain };
         // build all the region
         regions = {
-            header: getBlocks(allBlocks, 'header', { chart, data, theme, isStyleStatic }),
-            aboveFooter: getBlocks(allBlocks, 'aboveFooter', { chart, data, theme, isStyleStatic }),
-            footerLeft: getBlocks(allBlocks, 'footerLeft', { chart, data, theme, isStyleStatic }),
+            header: getBlocks(allBlocks, 'header', { chart, data, theme, isStyleStatic, config }),
+            aboveFooter: getBlocks(allBlocks, 'aboveFooter', {
+                chart,
+                data,
+                theme,
+                isStyleStatic,
+                config
+            }),
+            footerLeft: getBlocks(allBlocks, 'footerLeft', {
+                chart,
+                data,
+                theme,
+                isStyleStatic,
+                config
+            }),
             footerCenter: getBlocks(allBlocks, 'footerCenter', {
                 chart,
                 data,
                 theme,
                 isStyleStatic
             }),
-            footerRight: getBlocks(allBlocks, 'footerRight', { chart, data, theme, isStyleStatic }),
-            belowFooter: getBlocks(allBlocks, 'belowFooter', { chart, data, theme, isStyleStatic }),
-            afterBody: getBlocks(allBlocks, 'afterBody', { chart, data, theme, isStyleStatic }),
-            menu: getBlocks(allBlocks, 'menu', { chart, data, theme, isStyleStatic })
+            footerRight: getBlocks(allBlocks, 'footerRight', {
+                chart,
+                data,
+                theme,
+                isStyleStatic,
+                config
+            }),
+            belowFooter: getBlocks(allBlocks, 'belowFooter', {
+                chart,
+                data,
+                theme,
+                isStyleStatic,
+                config
+            }),
+            afterBody: getBlocks(allBlocks, 'afterBody', {
+                chart,
+                data,
+                theme,
+                isStyleStatic,
+                config
+            }),
+            menu: getBlocks(allBlocks, 'menu', { chart, data, theme, isStyleStatic, config })
         };
     }
 
@@ -235,6 +277,7 @@
     export let isStylePlain = false;
     // static style means user can't interact (e.g. in a png version)
     export let isStyleStatic = false;
+    export let frontendDomain = 'app.datawrapper.de';
 
     function getCaption(id) {
         if (id === 'd3-maps-choropleth' || id === 'd3-maps-symbols' || id === 'locator-map')

--- a/lib/Visualization.svelte
+++ b/lib/Visualization.svelte
@@ -102,10 +102,10 @@
             component: GetTheData
         },
         {
-            id: 'edit-in-datawrapper',
+            id: 'edit',
             region: 'footerLeft',
             test: ({ chart, isStyleStatic }) =>
-                get(theme, 'data.options.footer.getTheData.enabled') &&
+                get(chart, 'forkable') &&
                 get(chart, 'metadata.publish.edit-in-datawrapper', false) &&
                 !isStyleStatic,
             priority: 31,

--- a/lib/Visualization.svelte
+++ b/lib/Visualization.svelte
@@ -106,7 +106,7 @@
             region: 'footerLeft',
             test: ({ chart, isStyleStatic }) =>
                 get(chart, 'forkable') &&
-                get(chart, 'metadata.publish.edit-in-datawrapper', false) &&
+                get(chart, 'metadata.publish.blocks.edit-in-datawrapper', false) &&
                 !isStyleStatic,
             priority: 31,
             component: EditInDatawrapper

--- a/lib/blocks/EditInDatawrapper.svelte
+++ b/lib/blocks/EditInDatawrapper.svelte
@@ -8,6 +8,8 @@
     $: forkable = get(chart, 'forkable', false);
     $: showEditInDatawrapperLink = get(chart, 'metadata.publish.edit-in-datawrapper', false);
 
+    $: caption = get(theme, 'data.options.blocks.edit.data.caption', 'edit-in-datawrapper');
+
     function editInDatawrapper() {
         const form = document.createElement('form');
         form.setAttribute('method', 'post');
@@ -25,7 +27,5 @@
 </script>
 
 {#if forkable && showEditInDatawrapperLink}
-    <a href="#/edit-in-datawrapper" on:click|preventDefault={editInDatawrapper}>
-        Edit in Datawrapper
-    </a>
+    <a href="#/edit-in-datawrapper" on:click|preventDefault={editInDatawrapper}>{__(caption)}</a>
 {/if}

--- a/lib/blocks/EditInDatawrapper.svelte
+++ b/lib/blocks/EditInDatawrapper.svelte
@@ -6,7 +6,7 @@
 
     // internal props
     $: forkable = get(chart, 'forkable', false);
-    $: showEditInDatawrapperLink = get(chart, 'metadata.publish.edit-in-datawrapper', false);
+    $: showEditInDatawrapperLink = get(chart, 'metadata.publish.blocks.edit-in-datawrapper', false);
 
     $: caption = get(theme, 'data.options.blocks.edit.data.caption', 'edit-in-datawrapper');
 

--- a/lib/blocks/EditInDatawrapper.svelte
+++ b/lib/blocks/EditInDatawrapper.svelte
@@ -1,0 +1,31 @@
+<script>
+    // external props
+    export let props;
+    const { get, __, purifyHtml } = props;
+    $: ({ chart, theme, config } = props);
+
+    // internal props
+    $: forkable = get(chart, 'forkable', false);
+    $: showEditInDatawrapperLink = get(chart, 'metadata.publish.edit-in-datawrapper', false);
+
+    function editInDatawrapper() {
+        const form = document.createElement('form');
+        form.setAttribute('method', 'post');
+        form.setAttribute('target', '_blank');
+        form.setAttribute('action', `//${config.frontendDomain}/create/`);
+        const input = document.createElement('input');
+        input.setAttribute('type', 'hidden');
+        input.setAttribute('name', 'template');
+        input.setAttribute('value', chart.id);
+        form.appendChild(input);
+        document.body.appendChild(form);
+        form.submit();
+        document.body.removeChild(form);
+    }
+</script>
+
+{#if forkable && showEditInDatawrapperLink}
+    <a href="#/edit-in-datawrapper" on:click|preventDefault={editInDatawrapper}>
+        Edit in Datawrapper
+    </a>
+{/if}

--- a/lib/dw/chart.js
+++ b/lib/dw/chart.js
@@ -2,7 +2,6 @@ import { isArray, isUndefined, indexOf, clone } from 'underscore/modules';
 import get from '@datawrapper/shared/get';
 import set from '@datawrapper/shared/set';
 import significantDimension from '@datawrapper/shared/significantDimension';
-
 import json from './dataset/json';
 import delimited from './dataset/delimited';
 import { name } from './utils';
@@ -15,6 +14,10 @@ import createEmotion from '@emotion/css/create-instance';
 
 let visualization;
 
+/**
+ * Chart
+ * @module dw.chart
+ */
 export default function(attributes) {
     // private methods and properties
     let dataset;
@@ -32,7 +35,9 @@ export default function(attributes) {
 
     // public interface
     const chart = {
-        // returns an attribute
+        /**
+         * @function chart.get
+         */
         get(key, _default) {
             return get(attributes, key, _default);
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@datawrapper/chart-core",
-    "version": "8.31.0",
+    "version": "8.32.0-alpha.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@datawrapper/chart-core",
-            "version": "8.31.0",
+            "version": "8.32.0-alpha.0",
             "dependencies": {
                 "@datawrapper/expr-eval": "^2.0.2-datawrapper.1",
                 "@datawrapper/polyfills": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@datawrapper/chart-core",
-    "version": "8.31.0",
+    "version": "8.32.0-alpha.0",
     "description": "Svelte component to render charts. Used by Sapper App and Node API.",
     "main": "index.js",
     "files": [


### PR DESCRIPTION
This PR adds a new block to our visualization footer that lets viewers of a visualization create and edit a copy of it. This only forks for charts which are forkable and have the `metadata.publish.edit-in-datawrapper` attribute set to `true`.

- [x] add "Edit in Datawrapper" link block and hook it up to our `/create/` endpoint
- [x] translate caption (en and de for now)
- [x] allow overwriting of caption through theme
- [x] decide how we want to call this link, maybe "Edit in Datawrapper" is too much Datawrapper if shown alongside "Created with Datawrapper"

![grafik](https://user-images.githubusercontent.com/617518/117141375-f9f53700-ad9d-11eb-94ac-c874053d5107.png)

depends on
- https://github.com/datawrapper/api/pull/306
- https://github.com/datawrapper/frontend/pull/60
- https://github.com/datawrapper/schemas/pull/71