### PR TITLE
Change responsive script so that the minified version doesn't contain &&

### DIFF
--- a/lib/embed.js
+++ b/lib/embed.js
@@ -10,7 +10,8 @@ window.addEventListener('message', function(event) {
         for (var chartId in event.data['datawrapper-height']) {
             for (var i = 0; i < iframes.length; i++) {
                 if (iframes[i].contentWindow === event.source) {
-                    iframes[i].style.height = event.data['datawrapper-height'][chartId] + 'px';
+                    var frame = iframes[i];
+                    frame.style.height = event.data['datawrapper-height'][chartId] + 'px';
                 }
             }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@datawrapper/chart-core",
-    "version": "8.33.2",
+    "version": "8.33.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@datawrapper/chart-core",
-            "version": "8.33.2",
+            "version": "8.33.3",
             "dependencies": {
                 "@datawrapper/expr-eval": "^2.0.2-datawrapper.1",
                 "@datawrapper/polyfills": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@datawrapper/chart-core",
-    "version": "8.33.2",
+    "version": "8.33.3",
     "description": "Svelte component to render charts. Used by Sapper App and Node API.",
     "main": "index.js",
     "files": [


### PR DESCRIPTION
The current script results in a minified code that includes the `&&` operator. This turns out to be a problem because
CMSs have a tendency to convert instances of `&` into `&#038;` which breaks the script. This small change results in different minified code without any `&&`.