### PR TITLE
Don't pipe theme captions through translator

### DIFF
--- a/lib/blocks/Byline.svelte
+++ b/lib/blocks/Byline.svelte
@@ -7,28 +7,31 @@
     $: caption = props.caption;
 
     // internal props
-    $: fallBackCaption = caption === 'map' ? 'Map:' : caption === 'table' ? 'Table:' : 'Chart:';
     $: bylineCaption = get(
         theme,
         `data.options.blocks.byline.data.${caption}Caption`,
-        fallBackCaption
+        __(caption === 'map' ? 'Map:' : caption === 'table' ? 'Table:' : 'Chart:')
     );
 
     $: byline = get(chart, 'metadata.describe.byline', false);
 
-    $: forkCaption = get(theme, 'data.options.blocks.byline.data.forkCaption', 'footer / based-on');
+    $: forkCaption = get(
+        theme,
+        'data.options.blocks.byline.data.forkCaption',
+        __('footer / based-on')
+    );
 
     $: needBrackets = chart.basedOnByline && byline;
 
     $: basedOnByline =
         (needBrackets ? '(' : '') +
-        __(forkCaption) +
+        forkCaption +
         ' ' +
         purifyHtml(chart.basedOnByline) +
         (needBrackets ? ')' : '');
 </script>
 
-<span class="byline-caption">{__(bylineCaption)}</span>
+<span class="byline-caption">{bylineCaption}</span>
 {byline}
 {#if chart.basedOnByline}
     {@html purifyHtml(basedOnByline)}

--- a/lib/blocks/Embed.svelte
+++ b/lib/blocks/Embed.svelte
@@ -106,7 +106,9 @@
     }
 </style>
 
-<a href="#embed" class="chart-action-embed" on:click={handleClick}>{__(embed.caption)}</a>
+<a href="#embed" class="chart-action-embed" on:click={handleClick}>
+    {embed.caption || __('Embed')}
+</a>
 {#if !modalIsHidden}
     <div class="embed-code">
         <div class="close" on:click={handleClick}>

--- a/lib/blocks/GetTheData.svelte
+++ b/lib/blocks/GetTheData.svelte
@@ -5,14 +5,14 @@
     $: ({ chart, theme } = props);
 
     // internal props
-    $: caption = get(theme, 'data.options.blocks.get-the-data.data.caption');
+    $: caption = get(theme, 'data.options.blocks.get-the-data.data.caption', __('Get the data'));
     $: externalData = get(chart, 'externalData');
 </script>
 
 <a
     class="dw-data-link"
-    aria-label="{__(caption)}: {purifyHtml(chart.title, '')}"
+    aria-label="{caption}: {purifyHtml(chart.title, '')}"
     target={externalData ? '_blank' : '_self'}
     href={externalData || 'data'}>
-    {__(caption)}
+    {caption}
 </a>

--- a/lib/blocks/Source.svelte
+++ b/lib/blocks/Source.svelte
@@ -5,13 +5,13 @@
     $: ({ chart, theme } = props);
 
     // internal props
-    $: caption = get(theme, 'data.options.blocks.source.data.caption');
+    $: caption = get(theme, 'data.options.blocks.source.data.caption', __('Source'));
     $: sourceName = purifyHtml(get(chart, 'metadata.describe.source-name'));
     $: sourceUrl = get(chart, 'metadata.describe.source-url');
 </script>
 
 {#if sourceName}
-    <span class="source-caption">{__(caption)}:</span>
+    <span class="source-caption">{caption}:</span>
     {#if sourceUrl}
         <a class="source" target="_blank" rel="noopener noreferrer" href={sourceUrl}>
             {@html sourceName}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@datawrapper/chart-core",
-    "version": "8.35.4",
+    "version": "8.35.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@datawrapper/chart-core",
-            "version": "8.35.4",
+            "version": "8.35.5",
             "dependencies": {
                 "@datawrapper/expr-eval": "^2.0.3",
                 "@datawrapper/polyfills": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@datawrapper/chart-core",
-    "version": "8.35.4",
+    "version": "8.35.5",
     "description": "Svelte component to render charts. Used by Sapper App and Node API.",
     "main": "index.js",
     "engines": {


### PR DESCRIPTION
Currently some of the footer copy relies on the correct translation key being in the theme, which isn't very reliable. This PR changes that, so that we only translate if nothing is set in the theme.