### PR TITLE
Dont subtract 8px in getMaxChartHeight calculation

### DIFF
--- a/lib/dw/utils/getNonChartHeight.mjs
+++ b/lib/dw/utils/getNonChartHeight.mjs
@@ -33,6 +33,7 @@ export function getNonChartHeight() {
             h += Number(outerHeight(el, true));
         }
     }
+
     function hasClass(el, className) {
         return el.classList.contains(className);
     }
@@ -41,7 +42,7 @@ export function getNonChartHeight() {
         return getComputedStyle(document.querySelector(selector))[property].replace('px', '');
     }
 
-    const selectors = ['.dw-chart', '.dw-chart-body'];
+    const selectors = ['.dw-chart', '.dw-chart-body', 'body'];
     const properties = [
         'padding-top',
         'padding-bottom',

--- a/lib/dw/utils/index.mjs
+++ b/lib/dw/utils/index.mjs
@@ -49,8 +49,7 @@ export function name(obj) {
 
 export function getMaxChartHeight() {
     if (window.innerHeight === 0) return 0;
-    var maxH = window.innerHeight - 8;
-    maxH -= getNonChartHeight();
+    var maxH = window.innerHeight - getNonChartHeight();
     return Math.max(maxH, 0);
 }
 

--- a/lib/styles.less
+++ b/lib/styles.less
@@ -352,11 +352,6 @@ body {
 
     #footer,
     .dw-chart-footer {
-
-        .footer-right {
-            text-align:right;
-        }
-
         display: flex;
         justify-content: space-between;
         align-items: center;
@@ -379,6 +374,10 @@ body {
                 padding: 0;
                 border-bottom: 0;
             }
+        }
+
+        .footer-right {
+            text-align:right;
         }
 
         .separator {

--- a/lib/styles.less
+++ b/lib/styles.less
@@ -352,6 +352,11 @@ body {
 
     #footer,
     .dw-chart-footer {
+
+        .footer-right {
+            text-align:right;
+        }
+
         display: flex;
         justify-content: space-between;
         align-items: center;
@@ -360,7 +365,7 @@ body {
         margin: @style_footer_margin;
 
         & > div > .footer-block {
-            display: inline-block;
+            display: inline;
 
             &.hidden {
                 display: none;
@@ -381,7 +386,7 @@ body {
             font-style: initial;
 
             &:before {
-                content: '\00a0•';
+                content: '•';
                 content: @options_footer_separator;
                 display: inline-block;
             }

--- a/lib/styles.less
+++ b/lib/styles.less
@@ -2,7 +2,6 @@
 body {
     margin: 0;
     padding: 0;
-    box-sizing: content-box;
     background: @style_body_background;
 }
 

--- a/lib/styles.less
+++ b/lib/styles.less
@@ -2,7 +2,7 @@
 body {
     margin: 0;
     padding: 0;
-
+    box-sizing: content-box;
     background: @style_body_background;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@datawrapper/chart-core",
-    "version": "8.35.5",
+    "version": "8.35.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@datawrapper/chart-core",
-            "version": "8.35.5",
+            "version": "8.35.6",
             "dependencies": {
                 "@datawrapper/expr-eval": "^2.0.3",
                 "@datawrapper/polyfills": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@datawrapper/chart-core",
-    "version": "8.35.5",
+    "version": "8.35.6",
     "description": "Svelte component to render charts. Used by Sapper App and Node API.",
     "main": "index.js",
     "engines": {


### PR DESCRIPTION
For some very long-lived but by now unknown historical reason, we subtract 8px from the maxChartHeight. This means that there's always an extra 8px between the end of the `body` and the end of the html document:

![image](https://user-images.githubusercontent.com/19191012/120775249-51183400-c523-11eb-88dd-665f322f9029.png)

This is a problem in cases where it's very important that the bottom of the chart is really the bottom of the chart. Unless anyone knows a good reason to keep this, I would suggest we give removing it a go.