### PR TITLE
Make height mode class dynamic, add it to body as well

### DIFF
--- a/lib/render.mjs
+++ b/lib/render.mjs
@@ -48,6 +48,10 @@ function renderChart() {
     // compute chart dimensions
     const w = width($chart);
     const h = getMaxChartHeight($chart);
+    const heightMode = getHeightMode();
+    addClass(document.body, `vis-chart-${heightMode}`);
+    removeClass(document.querySelector('.dw-chart'),`vis-height-${heightMode === 'fit' ? 'fixed' : 'fit'}`);
+    addClass(document.querySelector('.dw-chart'), `vis-chart-${heightMode}`);
 
     let vis;
     if (__dw.vis && __dw.vis.supportsSmartRendering()) {

--- a/lib/render.mjs
+++ b/lib/render.mjs
@@ -50,7 +50,10 @@ function renderChart() {
     const h = getMaxChartHeight($chart);
     const heightMode = getHeightMode();
     addClass(document.body, `vis-chart-${heightMode}`);
-    removeClass(document.querySelector('.dw-chart'),`vis-height-${heightMode === 'fit' ? 'fixed' : 'fit'}`);
+    removeClass(
+        document.querySelector('.dw-chart'),
+        `vis-height-${heightMode === 'fit' ? 'fixed' : 'fit'}`
+    );
     addClass(document.querySelector('.dw-chart'), `vis-chart-${heightMode}`);
 
     let vis;

--- a/lib/styles.less
+++ b/lib/styles.less
@@ -3,6 +3,9 @@ body {
     margin: 0;
     padding: 0;
     background: @style_body_background;
+    &.vis-height-fit {
+        overflow: hidden;
+    }
 }
 
 .chart {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@datawrapper/chart-core",
-    "version": "8.35.6",
+    "version": "8.35.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@datawrapper/chart-core",
-            "version": "8.35.6",
+            "version": "8.35.7",
             "dependencies": {
                 "@datawrapper/expr-eval": "^2.0.3",
                 "@datawrapper/polyfills": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@datawrapper/chart-core",
-    "version": "8.35.6",
+    "version": "8.35.7",
     "description": "Svelte component to render charts. Used by Sapper App and Node API.",
     "main": "index.js",
     "engines": {


### PR DESCRIPTION
#### Motivation 

Currently the height mode class (e.g `vis-height-fixed` is [set server-side](https://github.com/datawrapper/api/blob/master/src/publish/index.pug#L11) on `.dw-chart`, and not updated e.g with the queryString `fitchart=1`. It's also not set on the `body`, as it used to be with the old rendering, which can cause single pixel overflow issues in some cases (now that we [don't have the 8px buffer anymore](https://github.com/datawrapper/chart-core/pull/139)).

#### Changes
- Apply height mode class to `body`
- Update height mode class on `.dw-chart`
- Apply `overflow:hidden` to `body.vis-height-fit`