### PR TITLE
Get theme fonts from theme object, rather than top level

### DIFF
--- a/lib/Visualization.svelte
+++ b/lib/Visualization.svelte
@@ -39,7 +39,6 @@
     export let isIframe;
     export let isPreview;
     export let assets;
-    export let fonts = {};
     export let styleHolder;
     export let origin;
     export let externalDataUrl;
@@ -473,7 +472,7 @@ Please make sure you called __(key) with a key of type "string".
         dwChart.render(isIframe);
 
         // await necessary reload triggers
-        observeFonts(fonts, theme.data.typography)
+        observeFonts(theme.fonts, theme.data.typography)
             .then(() => dwChart.render(isIframe))
             .catch(() => dwChart.render(isIframe));
 

--- a/lib/VisualizationIframe.svelte
+++ b/lib/VisualizationIframe.svelte
@@ -15,7 +15,6 @@
     export let chartAfterBodyHTML = '';
     export let isPreview;
     export let assets;
-    export let fonts = {};
     export let externalDataUrl;
 
     // plain style means no header and footer
@@ -63,7 +62,6 @@
     isIframe={true}
     {isPreview}
     {assets}
-    {fonts}
     {externalDataUrl}
     {isStylePlain}
     {isStyleStatic} />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@datawrapper/chart-core",
-    "version": "8.36.1",
+    "version": "8.36.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@datawrapper/chart-core",
-            "version": "8.36.1",
+            "version": "8.36.2",
             "dependencies": {
                 "@datawrapper/expr-eval": "^2.0.4",
                 "@datawrapper/polyfills": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@datawrapper/chart-core",
-    "version": "8.36.1",
+    "version": "8.36.2",
     "description": "Svelte component to render charts. Used by Sapper App and Node API.",
     "main": "index.js",
     "engines": {


### PR DESCRIPTION
We (now?) set the theme fonts in `theme.fonts`, rather than top level, ([here](https://github.com/datawrapper/api/blob/a5be32b556153d07aaf1970e176e33f2d71fa8f8/src/routes/charts/%7Bid%7D/publish.js#L340-L345)). This PR reflects that change which is required to ensure that `observeFonts` works, and that pdf export has access to the theme font json. This PR assumes moving theme fonts to the theme object was intended - if not we can adjust the publish endpoint instead.

Note that there's also currently a bug in the implementation in the publish endpoint, which would mean that the fonts would still actually not be defined here. That's being addressed in [datawrapper/api#349](https://github.com/datawrapper/api/pull/349).