### PR TITLE
Update is-mobile class on render

### DIFF
--- a/lib/Visualization.svelte
+++ b/lib/Visualization.svelte
@@ -376,7 +376,7 @@ Please make sure you called __(key) with a key of type "string".
     let isMobile = false;
     const checkBreakpoint = () => {
         const breakpoint = get(theme, `data.vis.${chart.type}.mobileBreakpoint`, 450);
-        isMobile = target.clientWidth <= breakpoint;
+        isMobile = target.parentElement.clientWidth <= breakpoint;
     };
 
     async function run() {

--- a/lib/Visualization.svelte
+++ b/lib/Visualization.svelte
@@ -374,12 +374,6 @@ Please make sure you called __(key) with a key of type "string".
         return translation;
     }
 
-    let isMobile = false;
-    const checkBreakpoint = () => {
-        const breakpoint = get(theme, `data.vis.${chart.type}.mobileBreakpoint`, 450);
-        isMobile = outerContainer.clientWidth <= breakpoint;
-    };
-
     async function run() {
         if (typeof dw === 'undefined') return;
 
@@ -512,9 +506,6 @@ Please make sure you called __(key) with a key of type "string".
     }
 
     onMount(async () => {
-        // check mobile breakpoint upon initialization
-        checkBreakpoint();
-
         await run();
 
         if (isIframe) {
@@ -583,7 +574,6 @@ Please make sure you called __(key) with a key of type "string".
     id="chart"
     bind:this={target}
     class:content-below-chart={contentBelowChart}
-    class:is-mobile={isMobile}
     aria-hidden={!!ariaDescription}
     class="dw-chart-body" />
 

--- a/lib/Visualization.svelte
+++ b/lib/Visualization.svelte
@@ -375,7 +375,11 @@ Please make sure you called __(key) with a key of type "string".
 
     let isMobile = false;
     const checkBreakpoint = () => {
-        const breakpoint = get(theme, `data.vis.${chart.type}.mobileBreakpoint`, 450);
+        const breakpoint = get(
+            theme,
+            `data.vis.${chart.type}.mobileBreakpoint`,
+            get(theme, 'data.mobileBreakpoint', 450)
+        );
         isMobile = target.parentElement.clientWidth <= breakpoint;
     };
 

--- a/lib/Visualization.svelte
+++ b/lib/Visualization.svelte
@@ -42,6 +42,7 @@
     export let styleHolder;
     export let origin;
     export let externalDataUrl;
+    export let outerContainer;
 
     // plain style means no header and footer
     export let isStylePlain = false;
@@ -376,7 +377,7 @@ Please make sure you called __(key) with a key of type "string".
     let isMobile = false;
     const checkBreakpoint = () => {
         const breakpoint = get(theme, `data.vis.${chart.type}.mobileBreakpoint`, 450);
-        isMobile = target.parentElement.clientWidth <= breakpoint;
+        isMobile = outerContainer.clientWidth <= breakpoint;
     };
 
     async function run() {
@@ -469,16 +470,16 @@ Please make sure you called __(key) with a key of type "string".
         }
 
         // render chart
-        dwChart.render(isIframe);
+        dwChart.render(isIframe, outerContainer);
 
         // await necessary reload triggers
         observeFonts(theme.fonts, theme.data.typography)
-            .then(() => dwChart.render(isIframe))
-            .catch(() => dwChart.render(isIframe));
+            .then(() => dwChart.render(isIframe, outerContainer))
+            .catch(() => dwChart.render(isIframe, outerContainer));
 
         // iPhone/iPad fix
         if (/iP(hone|od|ad)/.test(navigator.platform)) {
-            window.onload = dwChart.render(isIframe);
+            window.onload = dwChart.render(isIframe, outerContainer);
         }
 
         isIframe && initResizeHandler(target);
@@ -490,7 +491,7 @@ Please make sure you called __(key) with a key of type "string".
                 clearTimeout(reloadTimer);
                 reloadTimer = setTimeout(function() {
                     dwChart.vis().fire('resize');
-                    dwChart.render(isIframe);
+                    dwChart.render(isIframe, outerContainer);
                 }, 200);
             }
 
@@ -538,7 +539,7 @@ Please make sure you called __(key) with a key of type "string".
             afterUpdate(() => {
                 const newHeight = document.body.offsetHeight;
                 if (currentHeight !== newHeight && typeof dwChart.render === 'function') {
-                    dwChart.render(isIframe);
+                    dwChart.render(isIframe, outerContainer);
                     currentHeight = newHeight;
                 }
             });
@@ -548,7 +549,7 @@ Please make sure you called __(key) with a key of type "string".
             window.__dw.params = { data, visJSON: visualization };
             window.__dw.vis = vis;
             window.__dw.render = () => {
-                dwChart.render(isIframe);
+                dwChart.render(isIframe, outerContainer);
             };
             window.fontsJSON = theme.fonts;
         }

--- a/lib/Visualization.svelte
+++ b/lib/Visualization.svelte
@@ -375,11 +375,7 @@ Please make sure you called __(key) with a key of type "string".
 
     let isMobile = false;
     const checkBreakpoint = () => {
-        const breakpoint = get(
-            theme,
-            `data.vis.${chart.type}.mobileBreakpoint`,
-            get(theme, 'data.mobileBreakpoint', 450)
-        );
+        const breakpoint = get(theme, `data.vis.${chart.type}.mobileBreakpoint`, 450);
         isMobile = target.parentElement.clientWidth <= breakpoint;
     };
 

--- a/lib/VisualizationIframe.svelte
+++ b/lib/VisualizationIframe.svelte
@@ -16,6 +16,7 @@
     export let isPreview;
     export let assets;
     export let externalDataUrl;
+    export let outerContainer;
 
     // plain style means no header and footer
     export let isStylePlain = false;
@@ -64,4 +65,5 @@
     {assets}
     {externalDataUrl}
     {isStylePlain}
-    {isStyleStatic} />
+    {isStyleStatic}
+    {outerContainer} />

--- a/lib/dw/chart.mjs
+++ b/lib/dw/chart.mjs
@@ -207,7 +207,7 @@ export default function(attributes) {
             addClass(outerContainer, `vis-height-${heightMode}`);
 
             // set mobile class
-            const breakpoint = get(theme, `data.vis.${chart.type}.mobileBreakpoint`, 450);
+            const breakpoint = get(theme, `vis.${chart.type}.mobileBreakpoint`, 450);
 
             if (outerContainer.clientWidth <= breakpoint) {
                 addClass(container, 'is-mobile');

--- a/lib/dw/chart.mjs
+++ b/lib/dw/chart.mjs
@@ -203,7 +203,7 @@ export default function(attributes) {
 
             // set chart mode class
             addClass(container, `vis-height-${heightMode}`);
-            removeClass(chartContainer,`vis-height-${heightMode === 'fit' ? 'fixed' : 'fit'}`);
+            removeClass(chartContainer, `vis-height-${heightMode === 'fit' ? 'fixed' : 'fit'}`);
             addClass(chartContainer, `vis-height-${heightMode}`);
 
             // set mobile class

--- a/lib/dw/chart.mjs
+++ b/lib/dw/chart.mjs
@@ -199,26 +199,26 @@ export default function(attributes) {
                 return;
             }
 
-            const chartContainer = container.parentElement;
+            const outerContainer = container.parentElement;
 
             // set chart mode class
             addClass(container, `vis-height-${heightMode}`);
-            removeClass(chartContainer, `vis-height-${heightMode === 'fit' ? 'fixed' : 'fit'}`);
-            addClass(chartContainer, `vis-height-${heightMode}`);
+            removeClass(outerContainer, `vis-height-${heightMode === 'fit' ? 'fixed' : 'fit'}`);
+            addClass(outerContainer, `vis-height-${heightMode}`);
 
             // set mobile class
             const breakpoint = get(theme, `data.vis.${chart.type}.mobileBreakpoint`, 450);
 
             if (w <= breakpoint) {
                 addClass(container, 'is-mobile');
-                addClass(chartContainer, 'is-mobile');
+                addClass(outerContainer, 'is-mobile');
             } else {
                 removeClass(container, 'is-mobile');
-                removeClass(chartContainer, 'is-mobile');
+                removeClass(outerContainer, 'is-mobile');
             }
 
             // really needed?
-            chartContainer.classList.add('vis-' + visualization.id);
+            outerContainer.classList.add('vis-' + visualization.id);
 
             visualization.reset(container);
             visualization.size(w, h);

--- a/lib/dw/chart.mjs
+++ b/lib/dw/chart.mjs
@@ -187,12 +187,6 @@ export default function(attributes) {
                 : chart.getMetadata('publish.chart-height') || 400;
 
             const heightMode = chart.getHeightMode();
-            addClass(container, `vis-height-${heightMode}`);
-            removeClass(
-                container.querySelector('.dw-chart'),
-                `vis-height-${heightMode === 'fit' ? 'fixed' : 'fit'}`
-            );
-            addClass(container.querySelector('.dw-chart'), `vis-height-${heightMode}`);
 
             // only render if iframe has valid dimensions
             if (heightMode === 'fixed' ? w <= 0 : w <= 0 || h <= 0) {
@@ -205,8 +199,27 @@ export default function(attributes) {
                 return;
             }
 
+            const chartContainer = container.parentElement;
+
+            // set chart mode class
+            addClass(container, `vis-height-${heightMode}`);
+            removeClass(chartContainer,`vis-height-${heightMode === 'fit' ? 'fixed' : 'fit'}`);
+            addClass(chartContainer, `vis-height-${heightMode}`);
+
+            // set mobile class
+            const breakpoint = get(theme, `data.vis.${chart.type}.mobileBreakpoint`, 450);
+            const isMobile = w <= breakpoint;
+
+            if (isMobile) {
+                addClass(container, 'is-mobile');
+                addClass(chartContainer, 'is-mobile');
+            } else {
+                removeClass(container, 'is-mobile');
+                removeClass(chartContainer, 'is-mobile');
+            }
+
             // really needed?
-            container.parentElement.classList.add('vis-' + visualization.id);
+            chartContainer.classList.add('vis-' + visualization.id);
 
             visualization.reset(container);
             visualization.size(w, h);

--- a/lib/dw/chart.mjs
+++ b/lib/dw/chart.mjs
@@ -4,7 +4,7 @@ import set from '@datawrapper/shared/set.js';
 
 import json from './dataset/json.mjs';
 import delimited from './dataset/delimited.mjs';
-import { name, width, getMaxChartHeight, addClass, removeClass } from './utils/index.mjs';
+import { name, width, getMaxChartHeight } from './utils/index.mjs';
 import events from './utils/events.mjs';
 import reorderColumns from './dataset/reorderColumns.mjs';
 import applyChanges from './dataset/applyChanges.mjs';

--- a/lib/dw/chart.mjs
+++ b/lib/dw/chart.mjs
@@ -207,7 +207,11 @@ export default function(attributes) {
             addClass(outerContainer, `vis-height-${heightMode}`);
 
             // set mobile class
-            const breakpoint = get(theme, `data.vis.${chart.type}.mobileBreakpoint`, 450);
+            const breakpoint = get(
+                theme,
+                `vis.${chart.type}.mobileBreakpoint`,
+                theme.mobileBreakpoint || 450
+            );
 
             if (outerContainer.clientWidth <= breakpoint) {
                 addClass(container, 'is-mobile');

--- a/lib/dw/chart.mjs
+++ b/lib/dw/chart.mjs
@@ -209,7 +209,7 @@ export default function(attributes) {
             // set mobile class
             const breakpoint = get(theme, `data.vis.${chart.type}.mobileBreakpoint`, 450);
 
-            if (w <= breakpoint) {
+            if (outerContainer.clientWidth <= breakpoint) {
                 addClass(container, 'is-mobile');
                 addClass(outerContainer, 'is-mobile');
             } else {

--- a/lib/dw/chart.mjs
+++ b/lib/dw/chart.mjs
@@ -207,11 +207,7 @@ export default function(attributes) {
             addClass(outerContainer, `vis-height-${heightMode}`);
 
             // set mobile class
-            const breakpoint = get(
-                theme,
-                `vis.${chart.type}.mobileBreakpoint`,
-                theme.mobileBreakpoint || 450
-            );
+            const breakpoint = get(theme, `data.vis.${chart.type}.mobileBreakpoint`, 450);
 
             if (outerContainer.clientWidth <= breakpoint) {
                 addClass(container, 'is-mobile');

--- a/lib/dw/chart.mjs
+++ b/lib/dw/chart.mjs
@@ -208,9 +208,8 @@ export default function(attributes) {
 
             // set mobile class
             const breakpoint = get(theme, `data.vis.${chart.type}.mobileBreakpoint`, 450);
-            const isMobile = w <= breakpoint;
 
-            if (isMobile) {
+            if (w <= breakpoint) {
                 addClass(container, 'is-mobile');
                 addClass(chartContainer, 'is-mobile');
             } else {

--- a/lib/dw/chart.mjs
+++ b/lib/dw/chart.mjs
@@ -171,7 +171,7 @@ export default function(attributes) {
             }
         },
 
-        render(isIframe) {
+        render(isIframe, outerContainer) {
             if (!visualization || !theme || !dataset) {
                 throw new Error('cannot render the chart!');
             }
@@ -199,23 +199,15 @@ export default function(attributes) {
                 return;
             }
 
-            const outerContainer = container.parentElement;
-
             // set chart mode class
-            addClass(container, `vis-height-${heightMode}`);
-            removeClass(outerContainer, `vis-height-${heightMode === 'fit' ? 'fixed' : 'fit'}`);
-            addClass(outerContainer, `vis-height-${heightMode}`);
+            [container, outerContainer].forEach(el => {
+                el.classList.toggle('vis-height-fit', heightMode === 'fit');
+                el.classList.toggle('vis-height-fixed', heightMode === 'fixed');
+            });
 
             // set mobile class
             const breakpoint = get(theme, `vis.${chart.type}.mobileBreakpoint`, 450);
-
-            if (outerContainer.clientWidth <= breakpoint) {
-                addClass(container, 'is-mobile');
-                addClass(outerContainer, 'is-mobile');
-            } else {
-                removeClass(container, 'is-mobile');
-                removeClass(outerContainer, 'is-mobile');
-            }
+            outerContainer.classList.toggle('is-mobile', outerContainer.clientWidth <= breakpoint);
 
             // really needed?
             outerContainer.classList.add('vis-' + visualization.id);

--- a/main.mjs
+++ b/main.mjs
@@ -1,10 +1,13 @@
 import VisualizationIframe from './lib/VisualizationIframe.svelte';
-
 function render() {
+    const target = document.getElementById('__svelte-dw');
     /* eslint-disable no-new */
     new VisualizationIframe({
-        target: document.getElementById('__svelte-dw'),
-        props: window.__DW_SVELTE_PROPS__,
+        target,
+        props: {
+            ...window.__DW_SVELTE_PROPS__,
+            outerContainer: target
+        },
         hydrate: true
     });
 }

--- a/main.mjs
+++ b/main.mjs
@@ -1,4 +1,5 @@
 import VisualizationIframe from './lib/VisualizationIframe.svelte';
+
 function render() {
     const target = document.getElementById('__svelte-dw');
     /* eslint-disable no-new */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@datawrapper/chart-core",
-    "version": "8.36.2",
+    "version": "8.36.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@datawrapper/chart-core",
-            "version": "8.36.2",
+            "version": "8.36.3",
             "dependencies": {
                 "@datawrapper/expr-eval": "^2.0.4",
                 "@datawrapper/polyfills": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@datawrapper/chart-core",
-    "version": "8.36.2",
+    "version": "8.36.3",
     "description": "Svelte component to render charts. Used by Sapper App and Node API.",
     "main": "index.js",
     "engines": {


### PR DESCRIPTION
#### Motivation
The new rendering implementation would only apply the `.is-mobile` class on first render, but not subsequent renders.

![2021-07-19 12 57 59](https://user-images.githubusercontent.com/19191012/126150056-cf4d8592-4ee1-4e52-bb9c-73c4cb4fdc31.gif)

#### Changes

- update `is-mobile` class on each render
- apply `is-mobile` class to `.dw-chart` as well (needed for theming)
- use `.dw-chart`'s width to check for current width, rather than `.dw-chart-body` which may have a margin and therefore be narrower than the embed
- move classing logic to after the check for invalid dimensions that aborts rendering