### PR TITLE
Handle `forceLogo` parameter (which comes from `logo` querystring)

### DIFF
--- a/lib/Visualization.svelte
+++ b/lib/Visualization.svelte
@@ -49,7 +49,7 @@
     // static style means user can't interact (e.g. in a png version)
     export let isStyleStatic = false;
 
-    export let logoSetting = 'auto';
+    export let forceLogoSetting;
     export let frontendDomain = 'app.datawrapper.de';
 
     // .dw-chart-body
@@ -143,9 +143,10 @@
                 const logoData = get(theme, 'data.options.blocks.logo.data', {});
                 // theme has no logo
                 if (!logoData.imgSrc && !logoData.text) return false;
-                return logoSetting === 'forceOn'
+
+                return forceLogoSetting === true
                     ? true
-                    : logoSetting === 'forceOff'
+                    : forceLogoSetting === false
                     ? false
                     : get(chart, 'metadata.publish.blocks.logo');
             },

--- a/lib/Visualization.svelte
+++ b/lib/Visualization.svelte
@@ -49,7 +49,9 @@
     // static style means user can't interact (e.g. in a png version)
     export let isStyleStatic = false;
 
-    export let forceLogoSetting;
+    // can be on|off|auto (on/off will overwrite chart setting)
+    export let forceLogo = 'auto';
+
     export let frontendDomain = 'app.datawrapper.de';
 
     // .dw-chart-body
@@ -143,12 +145,9 @@
                 const logoData = get(theme, 'data.options.blocks.logo.data', {});
                 // theme has no logo
                 if (!logoData.imgSrc && !logoData.text) return false;
-
-                return forceLogoSetting === true
-                    ? true
-                    : forceLogoSetting === false
-                    ? false
-                    : get(chart, 'metadata.publish.blocks.logo');
+                if (forceLogo === 'on') return true;
+                if (forceLogo === 'off') return false;
+                return get(chart, 'metadata.publish.blocks.logo');
             },
             priority: 10,
             component: Logo

--- a/lib/Visualization.svelte
+++ b/lib/Visualization.svelte
@@ -48,6 +48,8 @@
     export let isStylePlain = false;
     // static style means user can't interact (e.g. in a png version)
     export let isStyleStatic = false;
+
+    export let logoSetting = 'auto';
     export let frontendDomain = 'app.datawrapper.de';
 
     // .dw-chart-body
@@ -137,10 +139,16 @@
         {
             id: 'logo',
             region: 'footerRight',
-            test: ({ chart, theme }) =>
-                get(chart, 'metadata.publish.blocks.logo') &&
-                (!!get(theme, 'data.options.blocks.logo.data.imgSrc') ||
-                    !!get(theme, 'data.options.blocks.logo.data.text')),
+            test: ({ chart, theme }) => {
+                const logoData = get(theme, 'data.options.blocks.logo.data', {});
+                // theme has no logo
+                if (!logoData.imgSrc && !logoData.text) return false;
+                return logoSetting === 'forceOn'
+                    ? true
+                    : logoSetting === 'forceOff'
+                    ? false
+                    : get(chart, 'metadata.publish.blocks.logo');
+            },
             priority: 10,
             component: Logo
         },

--- a/lib/VisualizationIframe.svelte
+++ b/lib/VisualizationIframe.svelte
@@ -24,6 +24,8 @@
     // static style means user can't interact (e.g. in a png version)
     export let isStyleStatic = false;
 
+    export let logoSetting = 'auto';
+
     $: customCSS = purifyHtml(get(chart, 'metadata.publish.custom-css', ''), '');
 
     window.__dwUpdate = newAttrs => {
@@ -66,4 +68,5 @@
     {externalDataUrl}
     {isStylePlain}
     {isStyleStatic}
+    {logoSetting}
     {outerContainer} />

--- a/lib/VisualizationIframe.svelte
+++ b/lib/VisualizationIframe.svelte
@@ -24,7 +24,7 @@
     // static style means user can't interact (e.g. in a png version)
     export let isStyleStatic = false;
 
-    export let logoSetting = 'auto';
+    export let forceLogoSetting;
 
     $: customCSS = purifyHtml(get(chart, 'metadata.publish.custom-css', ''), '');
 
@@ -68,5 +68,5 @@
     {externalDataUrl}
     {isStylePlain}
     {isStyleStatic}
-    {logoSetting}
+    {forceLogoSetting}
     {outerContainer} />

--- a/lib/VisualizationIframe.svelte
+++ b/lib/VisualizationIframe.svelte
@@ -24,7 +24,8 @@
     // static style means user can't interact (e.g. in a png version)
     export let isStyleStatic = false;
 
-    export let forceLogoSetting;
+    // can be on|off|auto (on/off will overwrite chart setting)
+    export let forceLogo = 'auto';
 
     $: customCSS = purifyHtml(get(chart, 'metadata.publish.custom-css', ''), '');
 
@@ -68,5 +69,5 @@
     {externalDataUrl}
     {isStylePlain}
     {isStyleStatic}
-    {forceLogoSetting}
+    {forceLogo}
     {outerContainer} />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@datawrapper/chart-core",
-    "version": "8.38.1",
+    "version": "8.38.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@datawrapper/chart-core",
-            "version": "8.38.1",
+            "version": "8.38.2",
             "dependencies": {
                 "@datawrapper/expr-eval": "^2.0.4",
                 "@datawrapper/polyfills": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@datawrapper/chart-core",
-    "version": "8.38.1",
+    "version": "8.38.2",
     "description": "Svelte component to render charts. Used by Sapper App and Node API.",
     "main": "index.js",
     "engines": {


### PR DESCRIPTION
So that we can make the logo an export setting. See [ticket](https://www.notion.so/datawrapper/Allow-users-to-configure-logo-to-be-shown-hidden-in-exported-PNG-5a961a96674047c4a19da1415685aa29)

If `undefined`, don't mess with the logo (status quo behavior). Otherwise use it to determine whether or not a logo should be rendered.