### PR TITLE
Remove timestamp from static.dwcdn.net call

### DIFF
--- a/lib/dw/dataset/delimited.mjs
+++ b/lib/dw/dataset/delimited.mjs
@@ -18,12 +18,8 @@ import column from './column.mjs';
 function delimited(opts) {
     function loadAndParseCsv() {
         if (opts.url) {
-            const ts = new Date().getTime();
-            const url = `${opts.url}${opts.url.indexOf('?') > -1 ? '&' : '?'}v=${
-                opts.url.indexOf('//static.dwcdn.net') > -1 ? ts - (ts % 60000) : ts
-            }`;
             return window
-                .fetch(url)
+                .fetch(opts.url)
                 .then(res => res.text())
                 .then(raw => {
                     return new DelimitedParser(opts).parse(raw);


### PR DESCRIPTION
We ignore the querystring here at Cloudflare level and invalidate the cache anyway, so this is redundant