### PR TITLE
Load chart dataset using the asset API

### DIFF
--- a/lib/Visualization.svelte
+++ b/lib/Visualization.svelte
@@ -28,7 +28,6 @@
     import purifyHtml from '@datawrapper/shared/purifyHtml.js';
     import { clean } from './shared.mjs';
 
-    export let data = '';
     export let chart;
     export let visualization = {};
     export let theme = {};
@@ -55,7 +54,7 @@
     export let frontendDomain = 'app.datawrapper.de';
 
     // .dw-chart-body
-    let target, dwChart, vis;
+    let target, dwChart, vis, data;
 
     $: {
         if (!get(chart, 'metadata.publish.blocks')) {
@@ -433,13 +432,14 @@ Please make sure you called __(key) with a key of type "string".
         // register chart assets
         const assetPromises = [];
         for (var name in assets) {
-            if (assets[name].shared) {
+            if (assets[name].url) {
+                const assetName = name;
                 assetPromises.push(
                     // eslint-disable-next-line
                     new Promise(async resolve => {
-                        const res = await fetch(assets[name].url);
+                        const res = await fetch(assets[assetName].url);
                         const text = await res.text();
-                        dwChart.asset(name, text);
+                        dwChart.asset(assetName, text);
                         resolve();
                     })
                 );
@@ -448,6 +448,8 @@ Please make sure you called __(key) with a key of type "string".
             }
         }
         await Promise.all(assetPromises);
+
+        data = dwChart.asset(`${chart.id}.${get(chart.metadata, 'data.json') ? 'json' : 'csv'}`);
 
         // initialize dw.vis object
         vis = dw.visualization(visualization.id, target);

--- a/lib/Visualization.svelte
+++ b/lib/Visualization.svelte
@@ -449,7 +449,7 @@ Please make sure you called __(key) with a key of type "string".
         }
         await Promise.all(assetPromises);
 
-        data = dwChart.asset(`${chart.id}.${get(chart.metadata, 'data.json') ? 'json' : 'csv'}`);
+        data = dwChart.asset(`dataset.${get(chart.metadata, 'data.json') ? 'json' : 'csv'}`);
 
         // initialize dw.vis object
         vis = dw.visualization(visualization.id, target);

--- a/lib/VisualizationIframe.svelte
+++ b/lib/VisualizationIframe.svelte
@@ -4,7 +4,6 @@
     import purifyHtml from '@datawrapper/shared/purifyHtml';
     import { onMount } from 'svelte';
 
-    export let data = '';
     export let chart = {};
     export let visualization = {};
     export let theme = {};
@@ -55,7 +54,6 @@
 </svelte:head>
 
 <Visualization
-    {data}
     {chart}
     {visualization}
     {theme}


### PR DESCRIPTION
depends on https://github.com/datawrapper/api/pull/368

Load the chart asset via the asset API rather than relying on it being part of the Svelte `props`