### PR TITLE
Don't send height postMessage when desired height is already present

### DIFF
--- a/lib/dw/chart.mjs
+++ b/lib/dw/chart.mjs
@@ -235,6 +235,11 @@ export default function(attributes) {
                     desiredHeight = outerHeight(document.querySelector('html'), true);
                 }
 
+                if (Math.round(window.innerHeight) === Math.round(desiredHeight)) {
+                    // no need to request a height change here
+                    return;
+                }
+
                 // datawrapper responsive embed
                 window.parent.postMessage(
                     {


### PR DESCRIPTION
When `window.innerHeight` is already the same as the visualization's desired height, skip sending the `postMessage`